### PR TITLE
Fix tag URLs to include language subdomain

### DIFF
--- a/common/models/Tag.php
+++ b/common/models/Tag.php
@@ -24,6 +24,7 @@ use yii\bootstrap\Html;
  */
 class Tag extends ActiveRecord
 {
+    public static $subdomen = null;
     /**
      * {@inheritdoc}
      */
@@ -135,5 +136,23 @@ class Tag extends ActiveRecord
             }
         }
         return $tagId;
+    }
+
+    public function getUrl()
+    {
+        if (is_null(self::$subdomen)) {
+            $host = explode('.', $_SERVER['SERVER_NAME']);
+            if (in_array($host[0], ['en', 'uk', 'ua', 'ru', 'no'])) {
+                self::$subdomen = $host[0];
+            } else {
+                self::$subdomen = '';
+            }
+        }
+
+        $tag = urlencode($this->name);
+        if (self::$subdomen === '') {
+            return SITE_PROTOCOL . "{$this->language->name}." . SITE_DOMAIN . "/tag/{$tag}";
+        }
+        return "/tag/{$tag}";
     }
 }

--- a/frontend/modules/poll/views/poll/view.php
+++ b/frontend/modules/poll/views/poll/view.php
@@ -63,7 +63,7 @@ if (!empty($poll->pollLanguage)) {
                     </div>
                     <div class="top_poll_b clearfix bottom_space_for_chart">
                         <?php foreach ($poll->tags as $pollTag) : ?>
-                            <a href="<?= Url::toRoute(['/poll/search/tag', 'tag' => $pollTag->name ]); ?>" class="link_poll">#<?= $pollTag->name; ?></a>
+                            <a href="<?= $pollTag->url ?>" class="link_poll">#<?= $pollTag->name; ?></a>
                         <?php endforeach; ?>
 
                         <span class="chosen_graph_b animated_b">

--- a/frontend/views/site/polls/_mainPolls.php
+++ b/frontend/views/site/polls/_mainPolls.php
@@ -8,7 +8,7 @@
         <div class="poll_block">
             <div class="top_poll_b clearfix">
                 <?php foreach($poll->Tags as $pollTag) :?>
-                    <a href="<?= Url::toRoute(['/poll/search/tag', 'tag' => $pollTag->name ]); ?>" class="link_poll">#<?php echo $pollTag->name; ?></a>
+                    <a href="<?= $pollTag->url ?>" class="link_poll">#<?php echo $pollTag->name; ?></a>
                 <?php endforeach; ?>
 
                 <span class="right_block_share_icon">

--- a/frontend/widgets/views/polls/_mainPolls.php
+++ b/frontend/widgets/views/polls/_mainPolls.php
@@ -1,6 +1,5 @@
 <?php
 
-use yii\helpers\Url;
 use common\helpers\StringHelper;
 use common\models\User;
 
@@ -16,7 +15,7 @@ use common\models\User;
         <div class="poll_block">
             <div class="top_poll_b clearfix">
                 <?php foreach($poll->tags as $pollTag) :?>
-                    <a href="<?= Url::toRoute(['/poll/search/tag', 'tag' => $pollTag->name ]); ?>" class="link_poll">#<?= $pollTag->name; ?></a>
+                    <a href="<?= $pollTag->url ?>" class="link_poll">#<?= $pollTag->name; ?></a>
                 <?php endforeach; ?>
 
                 <span class="right_block_share_icon">


### PR DESCRIPTION
## Summary
- Add Tag::getUrl to generate subdomain-aware tag links
- Use subdomain-based tag URLs in poll listings and poll view

## Testing
- `php vendor/bin/codecept run` *(fails: The application config file does not exist: /workspace/referendum/common/config/codeception-local.php)*

------
https://chatgpt.com/codex/tasks/task_b_68a75e241fc4832e9bb911e6f038f50d