### PR TITLE
Підключено капчу у формі реєстрації

### DIFF
--- a/frontend/controllers/SiteController.php
+++ b/frontend/controllers/SiteController.php
@@ -64,7 +64,7 @@ class SiteController extends Controller
             ],
             'captcha' => [
                 'class' => \yii\captcha\CaptchaAction::class,
-                'fixedVerifyCode' => YII_ENV_TEST ? 'testme' : null,
+                'fixedVerifyCode' => null,
             ],
         ];
     }

--- a/frontend/models/forms/RegisterForm.php
+++ b/frontend/models/forms/RegisterForm.php
@@ -87,11 +87,12 @@ class RegisterForm extends Model {
                 'agreeTerms',
                 'message' => Yii::t("main", 'Ви маєте погодитись з правилами та умовами сайту.')
             ),
-                /* array(
-                  'verifyCode',
-                  'captcha',
-                  'message'=>Yii::t("main", 'Введіть вірний код перевірки.')
-                  ), */
+            array(
+                'verifyCode',
+                'captcha',
+                'captchaAction' => 'site/captcha',
+                'message' => Yii::t("main", 'Введіть вірний код перевірки.')
+            ),
         );
     }
 

--- a/frontend/modules/ajax/views/modal/registrtion-step-one.php
+++ b/frontend/modules/ajax/views/modal/registrtion-step-one.php
@@ -57,21 +57,19 @@
 <?= Yii::t('main', 'Введіть код'); ?> *
                     </div>
                     <div class="right_reg_label item_param item_show clearfix">
-                        <input name="RegisterForm[verifyCode]" type="text" class="autocomplete for_captcha" value="">
-                        <span class="right_captcha_b">
-    <?= \yii\captcha\Captcha::widget([
-        'name' => 'RegisterForm[verifyCode]',
-        'captchaAction' => '/site/captcha',
-        'imageOptions' => [
-            'alt' => 'Captcha',
-            'title' => 'Натисніть для оновлення',
-            'style' => 'cursor:pointer;',
-            'onclick' => "this.src = this.src.split('?')[0] + '?' + Math.random();"
-        ],
-        'template' => '{image}',
-    ]); ?>
-</span>
-
+                        <?= \yii\captcha\Captcha::widget([
+            'name' => 'RegisterForm[verifyCode]',
+            'captchaAction' => 'site/captcha',
+            'options' => [
+                'class' => 'autocomplete for_captcha',
+            ],
+            'imageOptions' => [
+                'alt' => 'Captcha',
+                'title' => 'Натисніть для оновлення',
+                'class' => 'right_captcha_b',
+            ],
+            'template' => '{input}{image}',
+        ]); ?>
                     </div>
                 </div>
                 <div class="bottom_text_reg">

--- a/frontend/modules/poll/controllers/PollController.php
+++ b/frontend/modules/poll/controllers/PollController.php
@@ -449,15 +449,16 @@ Yii::$app->view->registerLinkTag([
     /*
     * Captcha
     */
-    public function actions(){
-        return array(
-            'captcha'=>array(
-                'class'=>'CCaptchaAction',
-                'height'=>80,
-                'width'=>160,
+    public function actions()
+    {
+        return [
+            'captcha' => [
+                'class' => \yii\captcha\CaptchaAction::class,
+                'height' => 80,
+                'width' => 160,
                 'offset' => 5,
-            ),
-        );
+            ],
+        ];
     }
 
     protected function checkRedirect() {

--- a/frontend/modules/user/controllers/UserYiiOneController.php
+++ b/frontend/modules/user/controllers/UserYiiOneController.php
@@ -525,14 +525,15 @@ class UserController extends Controller
     /*
          * Captcha
          */
-    public function actions(){
-        return array(
-            'captcha'=>array(
-                'class'=>'CCaptchaAction',
-                'height'=>80,
-                'width'=>160,
+    public function actions()
+    {
+        return [
+            'captcha' => [
+                'class' => \yii\captcha\CaptchaAction::class,
+                'height' => 80,
+                'width' => 160,
                 'offset' => 5,
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/frontend/widgets/views/user-sidebar-login.php
+++ b/frontend/widgets/views/user-sidebar-login.php
@@ -106,13 +106,19 @@ use frontend\helpers\Url;
                             <?php echo Yii::t("main", 'Введіть код'); ?> *
                         </div>
                         <div class="right_reg_label item_param item_show clearfix">
-                            <input name="RegisterForm[verifyCode]" type="text" class="autocomplete for_captcha" value="">
-                            <span class="right_captcha_b">
-                                <?php /* $this->widget('CCaptcha', array(
-                                    'showRefreshButton' => false,
-                                    'clickableImage' => true,
-                                )) /* *  / ?>
-                            </span>
+                            <?= \yii\captcha\Captcha::widget([
+                                'name' => 'RegisterForm[verifyCode]',
+                                'captchaAction' => 'site/captcha',
+                                'options' => [
+                                    'class' => 'autocomplete for_captcha',
+                                ],
+                                'imageOptions' => [
+                                    'alt' => 'Captcha',
+                                    'title' => 'Натисніть для оновлення',
+                                    'class' => 'right_captcha_b',
+                                ],
+                                'template' => '{input}{image}',
+                            ]); ?>
                         </div>
                     </div>
                     <div class="bottom_text_reg">


### PR DESCRIPTION
## Summary
- замінено статичне зображення на віджет капчі Yii2 у формах реєстрації
- оновлено контролери для використання `CaptchaAction` та прибрано тестовий фіксований код
- налаштовано серверну перевірку капчі через `RegisterForm`

## Testing
- `php vendor/bin/codecept run` *(помилка: Yii2 module is not configured; The application config file does not exist: /workspace/referendum/common/config/codeception-local.php)*

------
https://chatgpt.com/codex/tasks/task_b_68a8a826b738832e82d55348ef992f32