### PR TITLE
Виправлення видалення опитувань з очищенням голосів

### DIFF
--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -1180,6 +1180,28 @@ class Poll extends ActiveRecord
         }
     }
 
+    /**
+     * Видаляє всі пов'язані голоси перед видаленням опитування.
+     *
+     * Це усуває помилку цілісності та прибирає зайві записи.
+     *
+     * @return bool
+     */
+    public function beforeDelete()
+    {
+        if (!parent::beforeDelete()) {
+            return false;
+        }
+
+        $optionIds = $this->getPollOptions()->select('id')->column();
+        if (!empty($optionIds)) {
+            OptionGuestVote::deleteAll(['option_id' => $optionIds]);
+            OptionVote::deleteAll(['option_id' => $optionIds]);
+        }
+
+        return true;
+    }
+
     /*
      * Return user polls that has new comments
      */


### PR DESCRIPTION
## Опис
- Очищено голоси опцій перед видаленням опитування, щоб уникнути помилок цілісності

## Тестування
- `php vendor/bin/codecept run` *(помилка конфігурації: відсутній common/config/codeception-local.php)*


------
https://chatgpt.com/codex/tasks/task_b_68af1f07d430832eb96070692a603370