### PR TITLE
Додано підрахунок опитувань для тегів

### DIFF
--- a/backend/modules/poll/views/tag/index.php
+++ b/backend/modules/poll/views/tag/index.php
@@ -41,6 +41,7 @@ $this->params['breadcrumbs'][] = $this->title;
                 'value' => 'language.name',
             ],
             'description:raw',
+            'polls_count',
             //'created_by',
             //'updated_by',
             //'created_at:datetime',

--- a/common/models/PollTag.php
+++ b/common/models/PollTag.php
@@ -69,6 +69,25 @@ class PollTag extends \yii\db\ActiveRecord
         return $this->hasOne(Tag::class, ['id' => 'tag_id']);
     }
 
+    public function afterSave($insert, $changedAttributes)
+    {
+        parent::afterSave($insert, $changedAttributes);
+
+        if ($insert) {
+            Tag::updateAllCounters(['polls_count' => 1], ['id' => $this->tag_id]);
+        } elseif (array_key_exists('tag_id', $changedAttributes)) {
+            Tag::updateAllCounters(['polls_count' => -1], ['id' => $changedAttributes['tag_id']]);
+            Tag::updateAllCounters(['polls_count' => 1], ['id' => $this->tag_id]);
+        }
+    }
+
+    public function afterDelete()
+    {
+        parent::afterDelete();
+
+        Tag::updateAllCounters(['polls_count' => -1], ['id' => $this->tag_id]);
+    }
+
     /**
      * {@inheritdoc}
      * @return \common\models\query\PollTagQuery the active query used by this AR class.

--- a/common/models/Tag.php
+++ b/common/models/Tag.php
@@ -17,6 +17,7 @@ use yii\bootstrap\Html;
  * @property int|null $updated_by Updated by:
  * @property int|null $created_at Created at:
  * @property int|null $updated_at Updated at:
+ * @property int $polls_count Polls Count
  *
  * @property Language $language
  * @property PollTag[] $pollTags
@@ -40,7 +41,7 @@ class Tag extends ActiveRecord
     {
         return [
             [['name'], 'required'],
-            [['language_id', 'created_by', 'updated_by', 'created_at', 'updated_at'], 'integer'],
+            [['language_id', 'created_by', 'updated_by', 'created_at', 'updated_at', 'polls_count'], 'integer'],
             [['description'], 'string'],
             [['name'], 'string', 'max' => 255],
             [['language_id'], 'exist', 'skipOnError' => true, 'targetClass' => Language::class, 'targetAttribute' => ['language_id' => 'id']],
@@ -61,6 +62,7 @@ class Tag extends ActiveRecord
             'updated_by' => Yii::t('app', 'Updated by:'),
             'created_at' => Yii::t('app', 'Created at:'),
             'updated_at' => Yii::t('app', 'Updated at:'),
+            'polls_count' => Yii::t('app', 'Polls Count'),
         ];
     }
 

--- a/common/models/search/TagSearch.php
+++ b/common/models/search/TagSearch.php
@@ -17,7 +17,7 @@ class TagSearch extends Tag
     public function rules()
     {
         return [
-            [['id', 'language_id', 'created_by', 'updated_by', 'created_at', 'updated_at'], 'integer'],
+            [['id', 'language_id', 'created_by', 'updated_by', 'created_at', 'updated_at', 'polls_count'], 'integer'],
             [['name', 'description'], 'safe'],
         ];
     }
@@ -64,6 +64,7 @@ class TagSearch extends Tag
             'updated_by' => $this->updated_by,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
+            'polls_count' => $this->polls_count,
         ]);
 
         $query->andFilterWhere(['like', 'name', $this->name])

--- a/db/migrations/add_polls_count_to_tag.sql
+++ b/db/migrations/add_polls_count_to_tag.sql
@@ -1,0 +1,7 @@
+-- Add polls_count column to tag table and fill existing values
+ALTER TABLE tag ADD COLUMN polls_count INT NOT NULL DEFAULT 0;
+
+UPDATE tag t
+   SET polls_count = (
+       SELECT COUNT(*) FROM poll_tag pt WHERE pt.tag_id = t.id
+   );


### PR DESCRIPTION
## Опис
- додано поле `polls_count` для тегів
- додано автоматичне оновлення лічильника через `PollTag`
- в адмінці виведено кількість опитувань та сортування
- додано SQL-скрипт для створення колонки

## Інструкція з БД
```sql
ALTER TABLE tag ADD COLUMN polls_count INT NOT NULL DEFAULT 0;
UPDATE tag t
   SET polls_count = (
       SELECT COUNT(*) FROM poll_tag pt WHERE pt.tag_id = t.id
   );
```

## Тести
- `php vendor/bin/phpunit` *(виводить довідку, тестів не знайдено)*
- `php vendor/bin/codecept run` *(помилка конфігурації Yii2, відсутній `common/config/codeception-local.php`)*

------
https://chatgpt.com/codex/tasks/task_b_68af42e18998832e84435b3cfc4caf71