### PR TITLE
Налаштування PHPUnit та базові тести

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -34,6 +34,8 @@ php init
 
 ## Тестування
 
+Фреймворк PHPUnit налаштований у файлі `phpunit.xml`. Базові прикладові тести містяться в каталозі `tests/`.
+
 ```bash
 vendor/bin/phpunit
 ```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,0 +1,10 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+    public function testYiiVersionIsString(): void
+    {
+        $this->assertIsString(\Yii::getVersion());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';


### PR DESCRIPTION
## Опис
- додано конфігурацію `phpunit.xml` та початковий тест
- оновлено документацію щодо запуску тестів

## Тестування
- `php vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_b_68b0c849f298832e9f33fe0dfafdd7bf