### PR TITLE
Прибрано зайвий wrapper у макеті

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -116,3 +116,4 @@ php yii sitemap/index
 ## Валідація HTML
 
 - Атрибути `width` та `height` у логотипі хедера вказані без `px`, що відповідає стандарту HTML і проходить валідацію.
+- Видалено зайвий контейнер `<div class="wrapper">` із шаблону `frontend/views/layouts/main.php`, який спричиняв помилку «Unclosed element div».

--- a/frontend/views/layouts/main.php
+++ b/frontend/views/layouts/main.php
@@ -88,9 +88,8 @@ $locale = Yii::$app->language;
         <p class="last"><a href="#" id="btnCloseUpdateBrowser" title="Close">&times;</a></p>
     </div>
 
-    <div class="wrapper">
-        <?= $this->render('main/header'); ?>
-        <div class="content">
+    <?= $this->render('main/header'); ?>
+    <div class="content">
             <div class="sub_header_slider_b">
                 <?= WTopPollsSlider::widget(); ?>
             </div>
@@ -213,8 +212,6 @@ if ($tagName && ($getPage === null || (int)$getPage === 1)) {
                 </div>
             </div>
         </div>
-    </div>
-    <!-- .wrapper -->
 <?= $this->render('main/footer'); ?>
 <!-- Javascript
 ================================================== -->


### PR DESCRIPTION
## Опис
- вилучено зайвий контейнер `wrapper` у `frontend/views/layouts/main.php`
- оновлено документацію з приміткою щодо валідації HTML

## Тестування
- `php vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_b_68b60fdee498832e84034e1de122a2c5