### PR TITLE
Виправлення помилок форми реєстрації

### DIFF
--- a/frontend/modules/ajax/controllers/ModalController.php
+++ b/frontend/modules/ajax/controllers/ModalController.php
@@ -36,7 +36,7 @@ class ModalController extends Controller
 /* */
             }
             
-        return $this->renderPartial('registrtion-step-one', [
+        return $this->renderAjax('registrtion-step-one', [
             'registerForm'=>$model,
             'error'=>json_encode(Html::errorSummary($model)),
             ]);

--- a/frontend/modules/ajax/views/modal/registrtion-step-one.php
+++ b/frontend/modules/ajax/views/modal/registrtion-step-one.php
@@ -18,13 +18,13 @@
 * */ ?>
         <form method="post" action="/">
             <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>">
-            <div class="modal-body" id="registrationBody" style="border:1px dashed red;">
+            <div class="modal-body registration-body" style="border:1px dashed red;">
                 <div class="item_reg clearfix">
                     <div class="left_reg_label">
 <?= Yii::t('main', 'Логін'); ?> *
                     </div>
                     <div class="right_reg_label item_param item_show">
-                        <input name="RegisterForm[login]" id="login" type="text" class="autocomplete" value="<?= $registerForm->login; ?>">
+                        <input name="RegisterForm[login]" type="text" class="autocomplete" value="<?= $registerForm->login; ?>">
                     </div>
                 </div>
                 <div class="item_reg clearfix">
@@ -32,7 +32,7 @@
 <?= Yii::t('main', 'Email'); ?> *
                     </div>
                     <div class="right_reg_label item_param item_show email">
-                        <input name="RegisterForm[email]" id="email" type="text" class="autocomplete" value="<?= $registerForm->email; ?>">
+                        <input name="RegisterForm[email]" type="email" class="autocomplete" value="<?= $registerForm->email; ?>">
                         <a href="javascript:void(0)" class="del_btn"></a>
                     </div>
                 </div>
@@ -63,10 +63,11 @@
         'name' => 'RegisterForm[verifyCode]',
         'captchaAction' => '/site/captcha',
         'imageOptions' => [
+            'id' => 'registerform-verifycode-modal-image',
             'alt' => 'Captcha',
             'title' => 'Натисніть для оновлення',
+            'class' => 'captcha-image',
             'style' => 'cursor:pointer;',
-            'onclick' => "this.src = this.src.split('?')[0] + '?' + Math.random();"
         ],
         'template' => '{image}',
     ]); ?>
@@ -75,8 +76,8 @@
                     </div>
                 </div>
                 <div class="bottom_text_reg">
-                    <input name="RegisterForm[agreeTerms]" type="checkbox" id="agreeTerms">
-<?= Yii::t('main', 'Погоджуюсь з'); ?> <a href="#" id="rules-block"><?= Yii::t('main', 'Правилами та умовами'); ?></a> <?= Yii::t('main', 'сайту'); ?>.
+                    <input name="RegisterForm[agreeTerms]" type="checkbox" class="agree-terms">
+<?= Yii::t('main', 'Погоджуюсь з'); ?> <a href="#" class="rules-block-link"><?= Yii::t('main', 'Правилами та умовами'); ?></a> <?= Yii::t('main', 'сайту'); ?>.
                 </div>
                 <div class="clearfix"></div>
                 <div class="rules_block">
@@ -96,9 +97,9 @@
                 <div class="btn_b_modal">
                     <button type="submit" class="my_profile modal_add next_modal_btn"><?= Yii::t('main', 'ЗАРЕЄСТРУВАТИСЯ'); ?></button>
                 </div>
-                <a href="#" class="create_new_poll" id="registrationCancel" data-dismiss="modal"><?= Yii::t('main', 'Скасувати'); ?></a>
+                <a href="#" class="create_new_poll registration-cancel" data-dismiss="modal"><?= Yii::t('main', 'Скасувати'); ?></a>
             </div>
-        </FORM>
+        </form>
     </div>
 </div>
 

--- a/frontend/web/js/custom.js
+++ b/frontend/web/js/custom.js
@@ -466,23 +466,37 @@ function clearChartFilters(id,title){
     filterDataChart(id,title);
 }
 
-$(document).on('change','#login',function(){
+$(document).on('change','input[name="RegisterForm[login]"]', function(){
+    var $input = $(this);
     $.ajax({
         type: 'POST',
         url: '/site/checkLogin',
-        data: {login: $(this).val()},
+        data: {login: $input.val()},
         success: function (data) {
-            if(data == 1){
-                $('#login').after('<a href="#" class="del_btn active"></a>');
+            var $wrapper = $input.closest('.right_reg_label');
+            var $indicator = $wrapper.find('.del_btn.login-check');
+            if (parseInt(data, 10) === 1) {
+                if (!$indicator.length) {
+                    $indicator = $('<a/>', {
+                        href: 'javascript:void(0)',
+                        class: 'del_btn login-check active',
+                        'aria-label': 'Очистити логін'
+                    }).insertAfter($input);
+                } else {
+                    $indicator.addClass('active');
+                }
             } else {
-                $('.del_btn.active').remove();
+                $indicator.remove();
             }
         }
     });
 });
 
-$(document).on('click','.email .del_btn', function(){
-    $('#email').val('');
+$(document).on('click','.email .del_btn', function(event){
+    event.preventDefault();
+    var $container = $(this).closest('.email');
+    var $field = $container.find('input[name="RegisterForm[email]"]');
+    $field.val('').focus();
 });
 
 $(document).on('click','.clearComments',function(){
@@ -557,10 +571,12 @@ $(document).on('click','.city .del_btn',function(){
     $('#' + $(this).data('id') + ' #cityACPoll').val('');
 });
 
-$(document).on('click','#registrationCancel',function(){
-   $('#registrationBody input').val('');
-   $('#registrationBody #agreeTerms').attr("checked", false);
-    $('.del_btn.active').remove();
+$(document).on('click','.registration-cancel',function(){
+    var $modal = $(this).closest('.modal-content');
+    var $body = $modal.find('.registration-body');
+    $body.find('input[type="text"], input[type="password"], input[type="email"]').val('');
+    $body.find('input[type="checkbox"]').prop('checked', false);
+    $body.find('.del_btn.login-check').remove();
 });
 
 $(document).on('click','.newPollCancel',function(){

--- a/frontend/web/js/main.js
+++ b/frontend/web/js/main.js
@@ -122,12 +122,14 @@ function animationForZilla() {
     }
 }
 function openCloseRulesBlock() {
-    $('#rules-block').click(function(e){
-        $('.rules_block').slideDown();
+    $(document).on('click', '.rules-block-link', function(e){
+        var $container = $(this).closest('.registration-body');
+        var $rulesBlock = $container.find('.rules_block');
+        $rulesBlock.slideDown();
         e.preventDefault();
     });
-    $('.top_title_rules a').click(function(e){
-        $('.rules_block').slideUp();
+    $(document).on('click', '.top_title_rules a', function(e){
+        $(this).closest('.rules_block').slideUp();
         e.preventDefault();
     });
 }

--- a/frontend/widgets/views/user-sidebar-login.php
+++ b/frontend/widgets/views/user-sidebar-login.php
@@ -66,14 +66,15 @@ use frontend\helpers\Url;
                 <div class="modal_title"><?php echo Yii::t("main", 'Реєстрація'); ?></div>
             </div>
 <?php /* * / ?>
-            <FORM METHOD="POST" ACTION="/">
-                <div class="modal-body" id="registrationBody">
+            <form method="post" action="/">
+                <?= Html::hiddenInput(Yii::$app->request->csrfParam, Yii::$app->request->csrfToken); ?>
+                <div class="modal-body registration-body">
                     <div class="item_reg clearfix">
                         <div class="left_reg_label">
                             <?php echo Yii::t("main", 'Логін'); ?> *
                         </div>
                         <div class="right_reg_label item_param item_show">
-                            <input name="RegisterForm[login]" id="login" type="text" class="autocomplete" value="<?php echo $registerForm->login;?>">
+                            <input name="RegisterForm[login]" type="text" class="autocomplete" value="<?php echo $registerForm->login;?>">
                         </div>
                     </div>
                     <div class="item_reg clearfix">
@@ -81,7 +82,7 @@ use frontend\helpers\Url;
                             <?php echo Yii::t("main", 'Email'); ?> *
                         </div>
                         <div class="right_reg_label item_param item_show email">
-                            <input name="RegisterForm[email]" id="email" type="text" class="autocomplete" value="<?php echo $registerForm->email;?>">
+                            <input name="RegisterForm[email]" type="email" class="autocomplete" value="<?php echo $registerForm->email;?>">
                             <a href="javascript:void(0)" class="del_btn"></a>
                         </div>
                     </div>
@@ -112,10 +113,11 @@ use frontend\helpers\Url;
                                     'name' => 'RegisterForm[verifyCode]',
                                     'captchaAction' => '/site/captcha',
                                     'imageOptions' => [
+                                        'id' => 'registerform-verifycode-sidebar-image',
                                         'alt' => 'Captcha',
                                         'title' => 'Натисніть для оновлення',
+                                        'class' => 'captcha-image',
                                         'style' => 'cursor:pointer;',
-                                        'onclick' => "this.src = this.src.split('?')[0] + '?' + Math.random();",
                                     ],
                                     'template' => '{image}',
                                 ]);
@@ -124,8 +126,8 @@ use frontend\helpers\Url;
                         </div>
                     </div>
                     <div class="bottom_text_reg">
-                        <input name="RegisterForm[agreeTerms]" type="checkbox" id="agreeTerms">
-                        <?php echo Yii::t("main", 'Погоджуюсь з'); ?> <a href="#" id="rules-block"><?php echo Yii::t("main", 'Правилами та умовами'); ?></a> <?php echo Yii::t("main", 'сайту'); ?>.
+                        <input name="RegisterForm[agreeTerms]" type="checkbox" class="agree-terms">
+                        <?php echo Yii::t("main", 'Погоджуюсь з'); ?> <a href="#" class="rules-block-link"><?php echo Yii::t("main", 'Правилами та умовами'); ?></a> <?php echo Yii::t("main", 'сайту'); ?>.
                     </div>
                     <div class="clearfix"></div>
                     <div class="rules_block">
@@ -145,9 +147,9 @@ use frontend\helpers\Url;
                     <div class="btn_b_modal">
                         <button type="submit" class="my_profile modal_add next_modal_btn"><?php echo Yii::t("main", 'ЗАРЕЄСТРУВАТИСЯ'); ?></button>
                     </div>
-                    <a href="#" class="create_new_poll" id="registrationCancel" data-dismiss="modal"><?php echo Yii::t("main", 'Скасувати'); ?></a>
+                    <a href="#" class="create_new_poll registration-cancel" data-dismiss="modal"><?php echo Yii::t("main", 'Скасувати'); ?></a>
                 </div>
-            </FORM>
+            </form>
 <?php /* */ ?>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- замінив renderPartial на renderAjax для модального контролера, щоб скрипти капчі коректно підвантажувались
- оновив верстку форм реєстрації: додав CSRF-поле, уніфікував класи, прибирав дубльовані id та налаштував унікальні атрибути капчі
- переробив клієнтські скрипти для реєстрації: контекстні обробники для полів, новий механізм очищення, локальне відкривання блоку правил

## Testing
- php -l frontend/modules/ajax/controllers/ModalController.php
- php -l frontend/modules/ajax/views/modal/registrtion-step-one.php
- php -l frontend/widgets/views/user-sidebar-login.php

------
https://chatgpt.com/codex/tasks/task_b_68d18feb53e08320b9d959f01707658c