### PR TITLE
Видалено технічний файл і оптимізовано common/helpers/StringHelper.php

### DIFF
--- a/common/helpers/StringHelper.php
+++ b/common/helpers/StringHelper.php
@@ -44,25 +44,15 @@ class StringHelper {
      */
 
     public static function formatForBar($data) {
-        $result = array();
-        $result['series'] = '';
-
+        // Збираємо серії через масив, щоб уникнути зайвих конкатенацій у циклі.
+        $series = [];
         foreach ($data as $item) {
-            $option = ' ';
-            $value = 0;
-
-            if (isset($item['option'])) {
-                $option = $item['option'];
-            }
-
-            if (isset($item['value'])) {
-                $value = $item['value'];
-            }
-
-            $result['series'] .= "{name: '" . $option . "',data: [" . $value . "]},";
+            $option = $item['option'] ?? ' ';
+            $value = $item['value'] ?? 0;
+            $series[] = "{name: '" . $option . "',data: [" . $value . "]}";
         }
 
-        return $result;
+        return ['series' => empty($series) ? '' : implode(',', $series) . ','];
     }
 
     /*
@@ -83,27 +73,20 @@ class StringHelper {
      */
 
     public static function formatForPie($data) {
-        $result = '';
+        // Формуємо список елементів і склеюємо вкінці (менше операцій рядків).
+        $items = [];
         foreach ($data as $item) {
-            $option = ' ';
-            $value = 0;
-
-            if (isset($item['option'])) {
-                $option = $item['option'];
-            }
-
-            if (isset($item['value'])) {
-                $value = $item['value'];
-            }
+            $option = $item['option'] ?? ' ';
+            $value = $item['value'] ?? 0;
 
             if (isset($item['isMax'])) {
-                $result .= "{name:'" . $option . "',y:" . $value . ", sliced: true, selected: true },";
+                $items[] = "{name:'" . $option . "',y:" . $value . ", sliced: true, selected: true }";
             } else {
-                $result .= "['" . $option . "'," . $value . "],";
+                $items[] = "['" . $option . "'," . $value . "]";
             }
         }
 
-        return $result;
+        return empty($items) ? '' : implode(',', $items) . ',';
     }
 
     /*
@@ -202,17 +185,10 @@ class StringHelper {
      */
 
     public static function tagsToString($tags) {
-        $result = '';
-        if (count($tags) > 0) {
-            foreach ($tags as $index => $tag) {
-                $result .= $tag->name;
-                if ($index < count($tags) - 1) {
-                    $result .= ', ';
-                }
-            }
-        }
-
-        return $result;
+        // Використовуємо implode замість ручного циклу: коротше і швидше.
+        return implode(', ', array_map(static function ($tag) {
+            return $tag->name;
+        }, $tags));
     }
 
     /**

--- a/grj9dba2estfetfheq9phc96c9ghgjm3.txt
+++ b/grj9dba2estfetfheq9phc96c9ghgjm3.txt
@@ -1,1 +1,0 @@
-grj9dba2estfetfheq9phc96c9ghgjm3


### PR DESCRIPTION
### Motivation
- Підвищити продуктивність та читабельність самописного хелпера без зміни існуючої поведінки функцій.
- Видалити непотрібний технічний артефакт із репозиторію, щоб зменшити шум у кодовій базі.

### Description
- Видалено файл `grj9dba2estfetfheq9phc96c9ghgjm3.txt` як зайвий артефакт у корені проекту.
- Оптимізовано `formatForBar()` у `common/helpers/StringHelper.php` шляхом накопичення рядків у масив та фінального `implode` замість багаторазової конкатенації у циклі для кращої швидкодії.
- Оптимізовано `formatForPie()` аналогічно через буферизацію елементів у масив і `implode`, збережено вихідний формат рядка.
- Спрощено `tagsToString()` до `implode(', ', array_map(...))` та додано короткі коментарі у місцях оптимізації; весь функціонал збережено.

### Testing
- Перевірка синтаксису `php -l common/helpers/StringHelper.php` — успішно (синтаксичних помилок не виявлено).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d96bd6bfa4833385612f8127f80545)