### PR TITLE
Poll: centralize chart rendering, remove inline chart JS, and switch voting to POST

### DIFF
--- a/frontend/assets/AppAsset.php
+++ b/frontend/assets/AppAsset.php
@@ -49,6 +49,8 @@ class AppAsset extends AssetBundle
         '/js/custom.js',
         '/js/custom-modal.js',
         '/js/highCharts/highcharts.js',
+        // Централізований рендер графіків опитувань через один цикл.
+        '/js/poll-chart-queue.js',
 //        '/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js',
 
 

--- a/frontend/modules/poll/views/poll/options.php
+++ b/frontend/modules/poll/views/poll/options.php
@@ -1,7 +1,8 @@
 <?php
 
+use common\helpers\StringHelper;
 use frontend\helpers\Url;
-use yii\web\View;
+use yii\helpers\Json;
 
 /*
  * Раніше голосування виконувалось GET-посиланням на /poll/vote.
@@ -9,6 +10,13 @@ use yii\web\View;
  */
 
 ?>
+<?php if ($poll->result_type == 2) {
+    $result_type = 'column';
+} elseif ($poll->result_type == 1) {
+    $result_type = 'bar';
+} else {
+    $result_type = 'pie';
+} ?>
 <?php if(!$poll->isShowResult()):?>
     <form method="post" action="<?= Url::toRoute(['/poll/poll/vote']); ?>" class="poll-option-form">
         <!-- Один POST-формат на блок опитування, щоб не дублювати форму для кожної опції. -->
@@ -36,42 +44,19 @@ use yii\web\View;
         </form>
     </div>
 <?php else:?>
-    <div class="inner_container_graph" id="container<?= $poll->id; ?>"></div>
+    <?php
+    // Формуємо JSON-дані для централізованого рендера в окремому JS-файлі без inline-скриптів.
+    $chartConfigJson = Json::htmlEncode([
+        'category' => $result_type,
+        'id' => 'container' . $poll->id,
+        'title' => (string)$poll->title,
+        'series' => StringHelper::formatForBarAjax($chartData)['series'] ?? [],
+        'pie' => StringHelper::formatForPieAjax($chartData),
+    ]);
+    ?>
+    <div
+        class="inner_container_graph"
+        id="container<?= $poll->id; ?>"
+        data-chart-config='<?= $chartConfigJson; ?>'
+    ></div>
 <?php endif;?>
-
-<?php if($poll->result_type == 2){ $result_type = 'column'; }else if($poll->result_type == 1){ $result_type = 'bar';} else { $result_type = 'pie'; } ?>
-<?php /* */ ?>
-<script>
-
-</script>
-
-<?php 
-
-$jsRenderChart = <<<JS_RENDER_CHART
-/* DEV.JS f=~/frontend/modules/poll/views/poll/options.php */
-$(function () {
-        renderChart('{$result_type}','container{$poll->id}','{$poll->title}',[ {$bar['series']}],[{$pie}]);
-});
-JS_RENDER_CHART;
-$script = <<<JS_FINAL
-jQuery(document).ready(function() {
-{$jsRenderChart}
-
-});
-JS_FINAL;
-
-$this->registerJs($script, View::POS_END);
-
-
-/* */ ?>
-<?php
-/* DEV.JS f=~/frontend/modules/poll/views/poll/options.php */
-/*
-<script>
-    $(function () {
-        renderChart('<?php echo $result_type; ?>','container<?php echo $poll->id; ?>','<?php echo $poll->title;?>',[<?php echo $bar['series']; ?>],[<?php echo $pie;?>]);
-    });
-</script>
-
-
-<?php /* */ ?>

--- a/frontend/views/poll/options.php
+++ b/frontend/views/poll/options.php
@@ -1,8 +1,16 @@
 <?php
 
-//use yii\helpers\Url;
+use common\helpers\StringHelper;
 use frontend\helpers\Url;
-use yii\web\View;
+use yii\helpers\Json;
+
+if ($poll->result_type == 2) {
+    $result_type = 'column';
+} elseif ($poll->result_type == 1) {
+    $result_type = 'bar';
+} else {
+    $result_type = 'pie';
+}
 
 ?>
 <?php if(!$poll->isShowResult()):?>
@@ -32,43 +40,19 @@ use yii\web\View;
         </form>
     </div>
 <?php else: ?>
-    <div class="inner_container_graph" id="container<?= $poll->id; ?>"></div>
+    <?php
+    // Формуємо дані в JSON через ті самі helper-и, що й для AJAX, щоб зберегти сумісну структуру серій.
+    $chartConfigJson = Json::htmlEncode([
+        'category' => $result_type,
+        'id' => 'container' . $poll->id,
+        'title' => (string)$poll->title,
+        'series' => StringHelper::formatForBarAjax($chartData)['series'] ?? [],
+        'pie' => StringHelper::formatForPieAjax($chartData),
+    ]);
+    ?>
+    <div
+        class="inner_container_graph"
+        id="container<?= $poll->id; ?>"
+        data-chart-config='<?= $chartConfigJson; ?>'
+    ></div>
 <?php endif; ?>
-
-<?php
-if ($poll->result_type == 2) {
-    $result_type = 'column';
-} elseif ($poll->result_type == 1) {
-    $result_type = 'bar';
-} else {
-    $result_type = 'pie';
-}
-
-
-$jsRenderChart = <<<JS_RENDER_CHART
-/* DEV.JS f=~/frontend/views/poll/options.php */
-    $(function () {
-        renderChart('{$result_type}','container{$poll->id}','{$poll->title}',[{$bar['series']}],[{$pie}]);
-    });
-JS_RENDER_CHART;
-$script = <<<JS_FINAL
-jQuery(document).ready(function() {
-{$jsRenderChart}
-
-});
-JS_FINAL;
-
-$this->registerJs($script, View::POS_END);
-
-
-/* */ ?>
-
-<?php /* * / ?>
-<script>
-    <?php if($poll->result_type == 2){ $result_type = 'column'; }else if($poll->result_type == 1){ $result_type = 'bar';} else { $result_type = 'pie'; } ?>
-
-    $(function () {
-        renderChart('<?= $result_type; ?>','container<?= $poll->id; ?>','<?= $poll->title;?>',[<?= $bar['series']; ?>],[<?= $pie;?>]);
-    });
-</script>
-<?php /* */ ?>

--- a/frontend/web/js/poll-chart-queue.js
+++ b/frontend/web/js/poll-chart-queue.js
@@ -1,0 +1,31 @@
+(function ($) {
+    'use strict';
+
+    // Централізований рендер графіків: читаємо всі конфіги та малюємо в одному циклі.
+    $(function () {
+        var chartQueue = [];
+
+        $('.inner_container_graph[data-chart-config]').each(function () {
+            var rawConfig = $(this).attr('data-chart-config');
+            if (!rawConfig) {
+                return;
+            }
+
+            try {
+                chartQueue.push(JSON.parse(rawConfig));
+            } catch (error) {
+                // Не блокуємо решту графіків, якщо один конфіг пошкоджений.
+                console.error('Некоректний JSON у data-chart-config:', error, rawConfig);
+            }
+        });
+
+        for (var i = 0; i < chartQueue.length; i++) {
+            var item = chartQueue[i] || {};
+            if (!item.id || !item.category) {
+                continue;
+            }
+
+            renderChart(item.category, item.id, item.title || '', item.series || [], item.pie || []);
+        }
+    });
+})(jQuery);


### PR DESCRIPTION
### Motivation
- Eliminate inline JavaScript for poll chart rendering and consolidate chart initialization into a single client-side loop to improve maintainability and reduce duplicated script registrations.
- Prevent option IDs from appearing in URLs by switching voting to a single POST form per poll block.
- Load centralized poll chart renderer as a separate asset for consistent behavior across views.

### Description
- Added a new frontend script `frontend/web/js/poll-chart-queue.js` that collects `data-chart-config` from all `.inner_container_graph` elements and calls `renderChart` for each entry in one pass, with safe JSON parsing and error logging.
- Included the new script in `frontend/assets/AppAsset.php` so it is loaded with other frontend JS assets.
- Reworked poll view templates (`frontend/modules/poll/views/poll/options.php` and `frontend/views/poll/options.php`) to remove inline `registerJs` usage and instead emit a `data-chart-config` attribute containing a JSON-encoded configuration produced by `Json::htmlEncode` and helper formatting functions (`StringHelper::formatForBarAjax` and `StringHelper::formatForPieAjax`).
- Unified result type mapping (`2 -> column`, `1 -> bar`, else `pie`) and preserved chart `id` and `title` in the emitted config.
- Consolidated voting UI to use a single POST form per poll and added CSRF hidden inputs; kept a separate POST form for "see results" action.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9ebfffd548333855bb6f7b20657d3)