### PR TITLE
Локалізовано JS створення опитувань лише для /site/myPolls

### DIFF
--- a/frontend/assets/AppAsset.php
+++ b/frontend/assets/AppAsset.php
@@ -47,7 +47,8 @@ class AppAsset extends AssetBundle
         '/js/vendor/currency-autocomplete.js',
         '/js/main.js',
         '/js/custom.js',
-        '/js/custom-modal.js',
+        // Скрипт реєстраційної модалки лишається глобальним, бо використовується на різних сторінках.
+        '/js/registration-modal.js',
         '/js/highCharts/highcharts.js',
         // Централізований рендер графіків опитувань через один цикл.
         '/js/poll-chart-queue.js',

--- a/frontend/views/layouts/main.php
+++ b/frontend/views/layouts/main.php
@@ -94,23 +94,29 @@ $isMainIndexPage = (
     }
     ?>
     <script>
-        window.rfrndm = <?=
-    json_encode([
-        'csrf' => Yii::$app->request->csrfToken,
-        'locale' => Yii::$app->language,
-        'languageId' => Yii::$app->request->languageId,
-        'routes' => [
-            'ajax' => [
-                'registrtion_step_one' => Url::toRoute(['/ajax/modal/registrtion-step-one']),
-                'create_poll_step_one' => Url::toRoute(['/ajax/modal/create-poll-step-one']),
-                'poll_form_ajax' => Url::toRoute(['/ajax/modal/store-poll-form']),
+        <?php
+        // Базові JS-маршрути залишаємо глобально, а маршрути створення опитувань додаємо
+        // тільки для /site/myPolls, де ця функція справді потрібна.
+        $rfrndmConfig = [
+            'csrf' => Yii::$app->request->csrfToken,
+            'locale' => Yii::$app->language,
+            'languageId' => Yii::$app->request->languageId,
+            'routes' => [
+                'ajax' => [
+                    'registrtion_step_one' => Url::toRoute(['/ajax/modal/registrtion-step-one']),
+                ],
+                'customer' => [
+                    'home' => '/home',
+                ],
             ],
-            'customer' => [
-                'home' => "/home",
-            ]
-        ],
-    ]);
-    ?>;
+        ];
+
+        if (Yii::$app->controller->id === 'site' && Yii::$app->controller->action->id === 'my-polls') {
+            $rfrndmConfig['routes']['ajax']['create_poll_step_one'] = Url::toRoute(['/ajax/modal/create-poll-step-one']);
+            $rfrndmConfig['routes']['ajax']['poll_form_ajax'] = Url::toRoute(['/ajax/modal/store-poll-form']);
+        }
+        ?>
+        window.rfrndm = <?= json_encode($rfrndmConfig); ?>;
     </script>
 </head>
 

--- a/frontend/web/js/custom.js
+++ b/frontend/web/js/custom.js
@@ -244,56 +244,8 @@ $(document).ready(function(){
        $('.tabs_graphs li.active input').prop("checked", true);
     });
 
-    $(document).on('click','.modal-body .modal_add',function(){
-		var url = document.URL.split('.');
-		if(url[0] == 'http://ua'){
-			var left = 'Залишилось', chars = 'символів';
-		}
-		else if(url[0] == 'http://ru'){
-			var left = 'Осталось', chars = 'символов';
-		}
-		else if(url[0] == 'http://en'){
-			var left = 'Left', chars = 'symbols';
-		}
-
-        $('#new_poll'+$(this).data('id')+" .item_variants:last").after('<div class="item_variants"><span>'+(parseInt($('#new_poll'+$(this).data('id')+" .item_variants:last span").text())+1)+'</span><input type="text" value="" maxlength="60" class="variant_text answer_var" name="Poll[options][]"><div class="count_symbols">' + left + ': <div class="answer_left">60</div> ' + chars + '</div><a class="del_btn" href="#" data-id="'+$(this).data('id')+'"></a></div>');
-
-		$(function(){
-			var maxLength = $('.answer_var:last').attr('maxlength');
-			$('.answer_var:last').keyup(function()
-			{
-				var curLength = $(this).val().length;
-				$(this).val($(this).val().substr(0, maxLength));
-				var remaning = maxLength - curLength;
-				if (remaning < 0) remaning = 0;
-				$(this).next().find('.answer_left').html(remaning);
-			})
-		})
-
-	});
-
-    $(document).on('click','.item_variants .del_btn',function(){
-       $(this).parent().remove();
-        var arr = document.querySelectorAll('#new_poll'+$(this).data('id')+' .item_variants span');
-        for(var i = 0; i < arr.length; ++i){
-            $(arr[i]).replaceWith('<span>'+(i+1)+'</span>');
-        }
-    });
-
-    $('.answer_var').each(
-        function()
-        {
-            var maxLength = $(this).attr('maxlength'), input = $(this);
-            $(this).keyup(function()
-            {
-                    var curLength = $(this).val().length;
-                    $(this).val($(this).val().substr(0, maxLength));
-                    var remaning = maxLength - curLength;
-                    if (remaning < 0) remaning = 0;
-                    $(this).next().find('.answer_left').html(remaning);
-            })
-        }
-    );
+    // Логіку створення/редагування опитувань винесено в окремий poll-create-modal.js
+    // і підключаємо лише на /site/myPolls.
 
     $(document).on('click', '.copy_link', function(e){
         e.preventDefault();
@@ -590,27 +542,6 @@ function refreshCities(countryVal,regionVal,cityAC,cityClass,cityId){
             });
         }
     });
-}
-
-function getRandomInt(){
-    min = 1;
-    max = 100;
-    return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
-function refreshChart(popUpNum) {
-    title = $('#new_poll' + popUpNum + ' #title').val();
-    series = [];
-    pie = [];
-    options = document.querySelectorAll('#new_poll' + popUpNum + ' .variant_text');
-    for(var i = 0; i < options.length; ++i){
-        series[i] = {name: $(options[i]).val(), data: [getRandomInt()]};
-        pie[i] = [$(options[i]).val(),getRandomInt()];
-    }
-
-    renderChart('bar','new_poll'+popUpNum+' #horizontal_b_chart',title,series,pie);
-    renderChart('column','new_poll'+popUpNum+' #vertical_b_chart',title,series,pie);
-    renderChart('pie','new_poll'+popUpNum+' #pie_chart',title,series,pie);
 }
 
 function clearChartFilters(id,title){

--- a/frontend/web/js/poll-create-modal.js
+++ b/frontend/web/js/poll-create-modal.js
@@ -1,0 +1,136 @@
+console.log('~/js/poll-create-modal.js?ver:1.0');
+
+$(document).ready(function () {
+    try {
+        // Цей скрипт підключається тільки на сторінці /site/myPolls,
+        // щоб не тягнути логіку створення опитувань на інші сторінки.
+
+        $('#new_poll_next_step1').click(function () {
+            $('#poll_modal_content_step0').hide();
+            $('#poll_modal_content_step1').show();
+        });
+
+        $('#new_poll_back_step0').click(function () {
+            $('#poll_modal_content_step1').hide();
+            $('#poll_modal_content_step0').show();
+        });
+
+        $('#btn_create_new_poll').click(function () {
+            $('#my_profile_all').children('.modal-dialog')
+                .load(window.rfrndm.routes.ajax.create_poll_step_one, function (responseTxt, statusTxt, xhr) {
+                    if (statusTxt == 'success') {
+                        $('#new_poll_next_step1').click(function () {
+                            $('#poll_modal_content_step0').hide();
+                            $('#poll_modal_content_step1').show();
+                        });
+
+                        $('#new_poll_back_step0').click(function () {
+                            $('#poll_modal_content_step1').hide();
+                            $('#poll_modal_content_step0').show();
+                        });
+
+                        $('#poll-form').on('beforeSubmit', function () {
+                            var pollForm = $('#poll-form');
+                            var pollFormState = false;
+
+                            $.post(window.rfrndm.routes.ajax.poll_form_ajax, pollForm.serialize())
+                                .done(function (result) {
+                                    if (result.error_message) {
+                                        alert(result.error_message);
+                                    } else {
+                                        alert('Success[1]');
+                                    }
+                                })
+                                .fail(function (result) {
+                                    if (result.error_message) {
+                                        alert(result.error_message);
+                                    }
+                                });
+
+                            return pollFormState;
+                        });
+
+                        $(document).on('change', '.country', function () {
+                            window.refreshRegions($('.country').val(), $('span.region'), 'regionAC', 'region', 'cityAC', $('.city'), 'city');
+                            $('#regionAC').val('');
+                            $('#region').val(0);
+                        });
+                    }
+
+                    if (statusTxt == 'error') {
+                        alert('Error: ' + xhr.status + ': ' + xhr.statusText);
+                    }
+
+                    $('#my_profile_all').modal('show');
+                });
+        });
+
+        $(document).on('click', '.modal-body .modal_add', function () {
+            var url = document.URL.split('.');
+            var left = 'Left';
+            var chars = 'symbols';
+
+            if (url[0] == 'http://ua') {
+                left = 'Залишилось';
+                chars = 'символів';
+            } else if (url[0] == 'http://ru') {
+                left = 'Осталось';
+                chars = 'символов';
+            }
+
+            $('#new_poll' + $(this).data('id') + ' .item_variants:last').after('<div class="item_variants"><span>' + (parseInt($('#new_poll' + $(this).data('id') + ' .item_variants:last span').text()) + 1) + '</span><input type="text" value="" maxlength="60" class="variant_text answer_var" name="Poll[options][]"><div class="count_symbols">' + left + ': <div class="answer_left">60</div> ' + chars + '</div><a class="del_btn" href="#" data-id="' + $(this).data('id') + '"></a></div>');
+
+            var maxLength = $('.answer_var:last').attr('maxlength');
+            $('.answer_var:last').keyup(function () {
+                var curLength = $(this).val().length;
+                $(this).val($(this).val().substr(0, maxLength));
+                var remaning = maxLength - curLength;
+                if (remaning < 0) remaning = 0;
+                $(this).next().find('.answer_left').html(remaning);
+            });
+        });
+
+        $(document).on('click', '.item_variants .del_btn', function () {
+            $(this).parent().remove();
+            var arr = document.querySelectorAll('#new_poll' + $(this).data('id') + ' .item_variants span');
+            for (var i = 0; i < arr.length; ++i) {
+                $(arr[i]).replaceWith('<span>' + (i + 1) + '</span>');
+            }
+        });
+
+        $('.answer_var').each(function () {
+            var maxLength = $(this).attr('maxlength');
+            $(this).keyup(function () {
+                var curLength = $(this).val().length;
+                $(this).val($(this).val().substr(0, maxLength));
+                var remaning = maxLength - curLength;
+                if (remaning < 0) remaning = 0;
+                $(this).next().find('.answer_left').html(remaning);
+            });
+        });
+    } catch (error) {
+        console.error('Помилка в poll-create-modal.js. Ініціалізація створення опитування призупинена.', error);
+    }
+});
+
+// Глобальну функцію лишаємо сумісною зі старими inline-викликами з PHP-шаблонів.
+function refreshChart(popUpNum) {
+    function getRandomInt() {
+        var min = 1;
+        var max = 100;
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    var title = $('#new_poll' + popUpNum + ' #title').val();
+    var series = [];
+    var pie = [];
+    var options = document.querySelectorAll('#new_poll' + popUpNum + ' .variant_text');
+    for (var i = 0; i < options.length; ++i) {
+        series[i] = { name: $(options[i]).val(), data: [getRandomInt()] };
+        pie[i] = [$(options[i]).val(), getRandomInt()];
+    }
+
+    renderChart('bar', 'new_poll' + popUpNum + ' #horizontal_b_chart', title, series, pie);
+    renderChart('column', 'new_poll' + popUpNum + ' #vertical_b_chart', title, series, pie);
+    renderChart('pie', 'new_poll' + popUpNum + ' #pie_chart', title, series, pie);
+}

--- a/frontend/web/js/registration-modal.js
+++ b/frontend/web/js/registration-modal.js
@@ -1,0 +1,19 @@
+console.log('~/js/registration-modal.js?ver:1.0');
+
+$(document).ready(function () {
+    try {
+        // Реєстраційна модалка використовується не лише на /site/myPolls,
+        // тому ініціалізуємо її окремим легким скриптом.
+        $('.toggle_modal_registrtion').click(function () {
+            $('#registrtion_step_1').children('.modal-dialog')
+                .load(window.rfrndm.routes.ajax.registrtion_step_one, function (responseTxt, statusTxt, xhr) {
+                    if (statusTxt == 'error') {
+                        alert('Error: ' + xhr.status + ': ' + xhr.statusText);
+                    }
+                    $('#registrtion_step_1').modal('show');
+                });
+        });
+    } catch (error) {
+        console.error('Помилка в registration-modal.js. Ініціалізація модалки реєстрації призупинена.', error);
+    }
+});

--- a/frontend/widgets/views/poll-list.php
+++ b/frontend/widgets/views/poll-list.php
@@ -102,7 +102,13 @@ Menu::widget([
                 )); /* */
                 ?>
             <?php endif; ?>
-            <?= $this->render('//poll/_newPoll', array('model' => new Poll)); ?>
+            <?php
+            // Модалку та JS-логіку створення опитування тримаємо лише для "Мої опитування" (/site/myPolls),
+            // щоб не навантажувати інші сторінки зайвим функціоналом.
+            if ($category === 'own') {
+                echo $this->render('//poll/_newPoll', array('model' => new Poll));
+            }
+            ?>
         <?php else: ?>
             <?= $this->render('/user/profile', array('user' => $user, 'error' => $error, 'profileCategory' => $profileCategory, 'other' => $other)); ?>
 <?php endif; ?>
@@ -164,6 +170,13 @@ JS_THREE;
 $this->registerJs($scriptNotGuest);
 ?>
 <?php endif; ?>
+
+<?php
+// Підключаємо JavaScript створення опитувань лише на сторінці "Мої опитування".
+if ($category === 'own') {
+    $this->registerJsFile('/js/poll-create-modal.js', ['depends' => [\yii\web\JqueryAsset::class]]);
+}
+?>
 
 <?php /*
 <div class="col-md-8">


### PR DESCRIPTION
### Motivation
- Зменшити завантаження і ризик конфліктів, прибравши JavaScript, пов’язаний зі створенням опитувань, зі сторінок, де ця функція не використовується, і підключати його лише на сторінці `/site/myPolls`.

### Description
- Видалено глобальне підключення скрипту створення опитувань з `AppAsset` та додано окремий легкий скрипт `registration-modal.js` для реєстраційної модалки; змінено `frontend/assets/AppAsset.php` для цього.
- Винесено всю логіку модалки створення/редагування опитувань у новий файл `frontend/web/js/poll-create-modal.js` і залишивши там сумісну глобальну функцію `refreshChart` для шаблонів, які її викликають.
- Обмежено рендер модалки `//poll/_newPoll` і підключення `poll-create-modal.js` лише для категорії `own` (сторінка `/site/myPolls`) у `frontend/widgets/views/poll-list.php` та відповідно передається конфігурація AJAX-маршрутів у `frontend/views/layouts/main.php` лише для action `my-polls`.
- Прибрано пов’язані блоки створення опитувань з `frontend/web/js/custom.js` і залишено коментар про нове місце логіки, а також додано коментарі у нові файли для ясності.

### Testing
- Виконано синтаксичні перевірки PHP: `php -l frontend/assets/AppAsset.php`, `php -l frontend/widgets/views/poll-list.php`, `php -l frontend/views/layouts/main.php` — всі пройшли успішно.
- Перевірено JS синтаксис через Node: `node --check frontend/web/js/registration-modal.js`, `node --check frontend/web/js/poll-create-modal.js`, `node --check frontend/web/js/custom.js` — всі пройшли успішно.
- Локальна збірка файлів змін не виявила синтаксичних помилок у змінених скриптах; інтеграційні/енд-ту-енд тести не запускались у цьому PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9f4aa296483338a031c0e7fc83c9e)