### PR TITLE
Оптимізація DOM у топ-слайдері та компактніша HTML-розмітка

### DIFF
--- a/frontend/web/js/main.js
+++ b/frontend/web/js/main.js
@@ -28,36 +28,36 @@ $(window).resize(function(){
 })
 function initSliderHomepage() {
     var width = window.innerWidth;
-    // Вимикаємо нескінченну прокрутку, щоб bxSlider не додавав клоновані .slide елементи (bx-clone) у DOM.
-    // Це зменшує розмір дерева елементів без візуальних змін для користувача.
-    var sliderBaseConfig = {
-        moveSlides: 1,
-        pager: false,
-        controls: false,
-        infiniteLoop: false,
-        hideControlOnEnd: true
-    };
     if(width > 991){
-        slider = $('.slider').bxSlider($.extend({}, sliderBaseConfig, {
+        slider = $('.slider').bxSlider({
             slideWidth: 310,
             minSlides: 1,
             maxSlides: 3,
+            moveSlides: 1,
+            pager: false,
+            controls: false,
             slideMargin: 20
-        }));
+        });
     } else if ( 768 < width && width < 991){
-        slider = $('.slider').bxSlider($.extend({}, sliderBaseConfig, {
+        slider =$('.slider').bxSlider({
             slideWidth: 310,
             minSlides: 1,
             maxSlides: 2,
+            moveSlides: 1,
+            pager: false,
+            controls: false,
             slideMargin: 20
-        }));
+        });
     } else if (width < 768) {
-        slider = $('.slider').bxSlider($.extend({}, sliderBaseConfig, {
+        slider = $('.slider').bxSlider({
             slideWidth: 310,
             minSlides: 1,
             maxSlides: 1,
+            moveSlides: 1,
+            pager: false,
+            controls: false,
             slideMargin: 0
-        }));
+        });
     }
 }
 function hoverGraphBtn(){

--- a/frontend/web/js/main.js
+++ b/frontend/web/js/main.js
@@ -28,36 +28,36 @@ $(window).resize(function(){
 })
 function initSliderHomepage() {
     var width = window.innerWidth;
+    // Вимикаємо нескінченну прокрутку, щоб bxSlider не додавав клоновані .slide елементи (bx-clone) у DOM.
+    // Це зменшує розмір дерева елементів без візуальних змін для користувача.
+    var sliderBaseConfig = {
+        moveSlides: 1,
+        pager: false,
+        controls: false,
+        infiniteLoop: false,
+        hideControlOnEnd: true
+    };
     if(width > 991){
-        slider = $('.slider').bxSlider({
+        slider = $('.slider').bxSlider($.extend({}, sliderBaseConfig, {
             slideWidth: 310,
             minSlides: 1,
             maxSlides: 3,
-            moveSlides: 1,
-            pager: false,
-            controls: false,
             slideMargin: 20
-        });
+        }));
     } else if ( 768 < width && width < 991){
-        slider =$('.slider').bxSlider({
+        slider = $('.slider').bxSlider($.extend({}, sliderBaseConfig, {
             slideWidth: 310,
             minSlides: 1,
             maxSlides: 2,
-            moveSlides: 1,
-            pager: false,
-            controls: false,
             slideMargin: 20
-        });
+        }));
     } else if (width < 768) {
-        slider = $('.slider').bxSlider({
+        slider = $('.slider').bxSlider($.extend({}, sliderBaseConfig, {
             slideWidth: 310,
             minSlides: 1,
             maxSlides: 1,
-            moveSlides: 1,
-            pager: false,
-            controls: false,
             slideMargin: 0
-        });
+        }));
     }
 }
 function hoverGraphBtn(){

--- a/frontend/widgets/views/top-polls-slider.php
+++ b/frontend/widgets/views/top-polls-slider.php
@@ -25,9 +25,8 @@
                                     </span>
                                 </div>
                                 <div class="middle_text_info">
-                                    <?php echo Yii::t("poll", 'коментарів'); ?>: <?php echo count($poll->pollComments); ?><br>
-                                    <?php // Виводимо сумарну кількість голосів (зареєстровані + гості), щоб відображення у хедері було коректним. ?>
-                                    <?php echo Yii::t("poll", 'голосів'); ?>: <?php echo $poll->countPollOptionsVoters; ?>
+                                    <?php // Тримаємо обидва рядки статистики максимально щільно, без зайвих переносів/відступів у HTML-виводі. ?>
+                                    <?php echo Yii::t("poll", 'коментарів'); ?>: <?php echo count($poll->pollComments); ?><br><?php echo Yii::t("poll", 'голосів'); ?>: <?php echo $poll->countPollOptionsVoters; ?>
                                 </div>
                             </div>
                         </div>

--- a/frontend/widgets/views/top-polls-slider.php
+++ b/frontend/widgets/views/top-polls-slider.php
@@ -11,10 +11,8 @@
                     <div class="slide">
                         <div class="inner_slide_b">
                             <div class="item_normal">
-                                <?php // Лінк лише навколо тексту опитування, решта блоку лишається статичною. ?>
-                                <a class="poll_title_link" href="<?php echo $poll->url; ?>">
-                                    <?php echo $poll->title; ?>
-                                </a>
+                                <?php // Тримаємо посилання на один рядок, щоб HTML у вихідному коді сторінки був компактнішим і читабельнішим. ?>
+                                <a class="poll_title_link" href="<?php echo $poll->url; ?>"><?php echo $poll->title; ?></a>
                             </div>
                             <?php // Інформаційний шар наводить статистику і не блокує взаємодію з посиланням на назву. ?>
                             <div class="item_hover clearfix">


### PR DESCRIPTION
### Motivation
- Зменшити розмір DOM, який створює `bxSlider` через клонування слайдів, та зробити HTML у вихідному коді сторінки компактнішим і читабельнішим без зміни візуального вигляду.

### Description
- Винесено спільні налаштування `bxSlider` у `sliderBaseConfig` і вимкнено `infiniteLoop` з увімкненим `hideControlOnEnd` у `frontend/web/js/main.js`, щоб уникнути додаткових `.bx-clone` елементів у DOM. 
- Ініціалізацію слайдера приведено до об'єднання брейкпоінтних параметрів з `sliderBaseConfig`, при цьому збережено поточні `slideWidth`, `minSlides`, `maxSlides` і `slideMargin` для незмінного візуального представлення. 
- У шаблоні `frontend/widgets/views/top-polls-slider.php` скорочено розмітку заголовка опитування до одного рядка (`<a class="poll_title_link" href="...">...</a>`), додано короткі пояснювальні коментарі для підтримки читабельності коду. 

### Testing
- `php -l frontend/widgets/views/top-polls-slider.php` — пройшло успішно. 
- `php -l frontend/views/layouts/main.php` — пройшло успішно. 
- JS-синтаксис `frontend/web/js/main.js` перевірено через `node -e "new Function(require('fs').readFileSync('frontend/web/js/main.js','utf8'))"` — пройшло успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9febd86c883338a1acf75f3c08ff5)