### PR TITLE
Remove unused currency-autocomplete.js from frontend asset bundle

### DIFF
--- a/frontend/assets/AppAsset.php
+++ b/frontend/assets/AppAsset.php
@@ -44,7 +44,7 @@ class AppAsset extends AssetBundle
         '/js/vendor/jquery.bxslider.min.js',
         '/js/vendor/jquery.autocomplete.js',
 //        '/js/vendor/jquery.autocomplete.min.js',
-        '/js/vendor/currency-autocomplete.js',
+        // Прибрано неактуальний currency-autocomplete: цільові селектори відсутні у поточних шаблонах.
         '/js/main.js',
         '/js/custom.js',
         // Скрипт реєстраційної модалки лишається глобальним, бо використовується на різних сторінках.


### PR DESCRIPTION
### Motivation
- Remove an obsolete frontend asset that is no longer targeted by current templates to avoid loading unused code and potential errors.

### Description
- Updated `frontend/assets/AppAsset.php` to remove the `/js/vendor/currency-autocomplete.js` entry and replaced it with an inline comment explaining the removal.
- Left other asset registrations and comments intact to preserve existing preload behavior and script ordering.

### Testing
- No automated tests were executed for this small asset-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69da4e672bc083338777f7fb3a0a930e)