### PR TITLE
Прибрано службові коментарі з шаблонів опитувань

### DIFF
--- a/frontend/modules/poll/views/poll/options.php
+++ b/frontend/modules/poll/views/poll/options.php
@@ -19,13 +19,10 @@ use yii\helpers\Json;
 } ?>
 <?php if(!$poll->isShowResult()):?>
     <form method="post" action="<?= Url::toRoute(['/poll/poll/vote']); ?>" class="poll-option-form">
-        <!-- Один POST-формат на блок опитування, щоб не дублювати форму для кожної опції. -->
-        <!-- Відправляємо голос POST-запитом, щоб не показувати ідентифікатор опції в адресному рядку. -->
         <input type="hidden" name="<?= Yii::$app->request->csrfParam ?>" value="<?= Yii::$app->request->getCsrfToken() ?>">
         <?php foreach($poll->pollOptions as $option):?>
             <div class="item_chose_poll">
                 <button type="submit" class="radio_link poll-option-vote" name="option" value="<?= $option->id; ?>">
-                    <!-- Новий чіткий індикатор вибору без зображень. -->
                     <span class="radio_indicator"></span>
                     <span class="link_text"><?= (YII_ENV != 'dev') ? '' : "[{$option->id}]:"; ?><?= $option->title; ?></span>
                 </button>
@@ -37,7 +34,6 @@ use yii\helpers\Json;
             <input type="hidden" name="<?= Yii::$app->request->csrfParam ?>" value="<?= Yii::$app->request->getCsrfToken() ?>">
             <input type="hidden" name="result" value="1">
             <button type="submit" class="radio_link poll-see-results">
-                <!-- Новий чіткий індикатор вибору без зображень. -->
                 <span class="radio_indicator"></span>
                 <span class="link_text"><?= Yii::t('poll', 'Побачити результати'); ?></span>
             </button>

--- a/frontend/modules/poll/views/poll/view.php
+++ b/frontend/modules/poll/views/poll/view.php
@@ -65,7 +65,6 @@ JS
                     <meta itemprop="mainEntityOfPage" content="<?= Yii::$app->request->absoluteUrl;?>" />
                     <meta itemprop="url" content="<?= Yii::$app->request->absoluteUrl;?>" />
 
-                    <!-- Виносимо рейтинг і заголовок в окремий контейнер для вертикального центрування. -->
                     <div class="poll_heading_b clearfix">
                         <div class="left_rating_b" itemprop="interactionStatistic" itemscope itemtype="https://schema.org/InteractionCounter">
                             <a href="javascript:void(0)" class="arrow_rating_top" data-id="<?= $poll->id; ?>"></a><br>

--- a/frontend/views/poll/options.php
+++ b/frontend/views/poll/options.php
@@ -15,13 +15,10 @@ if ($poll->result_type == 2) {
 ?>
 <?php if(!$poll->isShowResult()):?>
     <form method="post" action="<?= Url::toRoute(['/poll/poll/vote']); ?>" class="poll-option-form">
-        <!-- Один POST-формат на блок опитування, щоб уникнути дублювання форм. -->
-        <!-- Відправляємо голос POST-запитом, щоб URL не містив параметрів голосування. -->
         <input type="hidden" name="<?= Yii::$app->request->csrfParam ?>" value="<?= Yii::$app->request->getCsrfToken() ?>">
         <?php foreach($poll->pollOptions as $option): ?>
             <div class="item_chose_poll">
                 <button type="submit" class="radio_link poll-option-vote" name="option" value="<?= $option->id; ?>">
-                    <!-- Новий чіткий індикатор вибору без зображень. -->
                     <span class="radio_indicator"></span>
                     <span class="link_text"><?= $option->title; ?></span>
                 </button>
@@ -33,7 +30,6 @@ if ($poll->result_type == 2) {
             <input type="hidden" name="<?= Yii::$app->request->csrfParam ?>" value="<?= Yii::$app->request->getCsrfToken() ?>">
             <input type="hidden" name="result" value="1">
             <button type="submit" class="radio_link poll-see-results">
-                <!-- Новий чіткий індикатор вибору без зображень. -->
                 <span class="radio_indicator"></span>
                 <span class="link_text"><?= Yii::t('poll', 'Побачити результати'); ?></span>
             </button>

--- a/frontend/views/poll/view.php
+++ b/frontend/views/poll/view.php
@@ -22,7 +22,6 @@ if (!empty($poll->pollLanguage)) {
                     <?php $chartData = $poll->getChartData();?>
                     <?php $bar = StringHelper::formatForBar($chartData); ?>
                     <?php $pie = StringHelper::formatForPie($chartData); ?>
-                    <!-- Виносимо рейтинг і заголовок в окремий контейнер для вертикального центрування. -->
                     <div class="poll_heading_b clearfix">
 						<div class="left_rating_b">
 							<a href="javascript:void(0)" class="arrow_rating_top" data-id="<?php echo $poll->id; ?>"></a><br>

--- a/frontend/views/site/polls/_mainPolls.php
+++ b/frontend/views/site/polls/_mainPolls.php
@@ -23,7 +23,6 @@
             <?php $chartData = $poll->getChartData();?>
             <?php $bar = StringHelper::formatForBar($chartData); ?>
             <?php $pie = StringHelper::formatForPie($chartData); ?>
-            <!-- Виносимо рейтинг і заголовок в окремий контейнер для вертикального центрування. -->
             <div class="poll_heading_b clearfix">
                 <div class="left_rating_b">
                     <a href="javascript:void(0)" class="arrow_rating_top" data-id="<?php echo $poll->id; ?>"></a><br>
@@ -34,7 +33,6 @@
                     <div class="title_poll">
                         <a href="<?= $poll->url ?>"><?= $poll->title; ?></a>
                     </div>
-                    <?php /* h3>#DEV1.a</h3> */ ?>
                 </div>
             </div>
             <div class="middle_name_poll_b clearfix">

--- a/frontend/widgets/views/poll-list.php
+++ b/frontend/widgets/views/poll-list.php
@@ -314,7 +314,6 @@ if ($category === 'own') {
 </span>                </span>
 
                             </div>
-            <!-- Виносимо рейтинг і заголовок в окремий контейнер для вертикального центрування. -->
             <div class="poll_heading_b clearfix">
                 <div class="left_rating_b">
                     <a href="javascript:void(0)" class="arrow_rating_top" data-id="382"></a><br>
@@ -325,7 +324,6 @@ if ($category === 'own') {
                     <div class="title_poll">
                         <a href="#P#/poll/382">Do you think that Trump is Traitor? </a>
                     </div>
-                    <h3>#DEV1</h3>
                 </div>
             </div>
             <div class="middle_name_poll_b clearfix">
@@ -371,7 +369,6 @@ if ($category === 'own') {
 </span>                </span>
 
                             </div>
-            <!-- Виносимо рейтинг і заголовок в окремий контейнер для вертикального центрування. -->
             <div class="poll_heading_b clearfix">
                 <div class="left_rating_b">
                     <a href="javascript:void(0)" class="arrow_rating_top" data-id="383"></a><br>
@@ -382,25 +379,21 @@ if ($category === 'own') {
                     <div class="title_poll">
                         <a href="#P#/poll/383">Do you think, that Trump Will go to Prison?</a>
                     </div>
-                    <h3>#DEV1</h3>
                 </div>
             </div>
             <div class="middle_name_poll_b clearfix">
                                                                                                         <div class="inner_block_chosen">
                                         <form method="post" action="/poll/poll/vote" class="poll-option-form">
-                <?php // Один POST-формат на блок опитування, щоб уникнути дублювання форм. ?>
                 <?php // Додаємо CSRF-токен, аби POST-запит із голосом пройшов стандартну перевірку Yii. ?>
                 <?= Html::hiddenInput($csrfParam, $csrfToken); ?>
                 <div class="item_chose_poll">
                 <button type="submit" class="radio_link poll-option-vote" name="option" value="1512">
-                    <!-- Новий чіткий індикатор вибору без зображень. -->
                     <span class="radio_indicator"></span>
                     <span class="link_text">Yes</span>
                 </button>
                 </div>
                 <div class="item_chose_poll">
                 <button type="submit" class="radio_link poll-option-vote" name="option" value="1513">
-                    <!-- Новий чіткий індикатор вибору без зображень. -->
                     <span class="radio_indicator"></span>
                     <span class="link_text">No</span>
                 </button>
@@ -449,7 +442,6 @@ if ($category === 'own') {
 </span>                </span>
 
                             </div>
-            <!-- Виносимо рейтинг і заголовок в окремий контейнер для вертикального центрування. -->
             <div class="poll_heading_b clearfix">
                 <div class="left_rating_b">
                     <a href="javascript:void(0)" class="arrow_rating_top" data-id="401"></a><br>
@@ -460,25 +452,21 @@ if ($category === 'own') {
                     <div class="title_poll">
                         <a href="#P#/poll/401">Do you stand with Steve Bannon? </a>
                     </div>
-                    <h3>#DEV1</h3>
                 </div>
             </div>
             <div class="middle_name_poll_b clearfix">
                                                                                                         <div class="inner_block_chosen">
                                         <form method="post" action="/poll/poll/vote" class="poll-option-form">
-                <?php // Один POST-формат на блок опитування, щоб уникнути дублювання форм. ?>
                 <?php // Додаємо CSRF-токен, аби POST-запит із голосом пройшов стандартну перевірку Yii. ?>
                 <?= Html::hiddenInput($csrfParam, $csrfToken); ?>
                 <div class="item_chose_poll">
                 <button type="submit" class="radio_link poll-option-vote" name="option" value="1554">
-                    <!-- Новий чіткий індикатор вибору без зображень. -->
                     <span class="radio_indicator"></span>
                     <span class="link_text">Yes</span>
                 </button>
                 </div>
                 <div class="item_chose_poll">
                 <button type="submit" class="radio_link poll-option-vote" name="option" value="1555">
-                    <!-- Новий чіткий індикатор вибору без зображень. -->
                     <span class="radio_indicator"></span>
                     <span class="link_text">No</span>
                 </button>

--- a/frontend/widgets/views/polls/_mainPolls.php
+++ b/frontend/widgets/views/polls/_mainPolls.php
@@ -30,7 +30,6 @@ use common\models\User;
             <?php $chartData = $poll->getChartData();?>
             <?php $bar = StringHelper::formatForBar($chartData); ?>
             <?php $pie = StringHelper::formatForPie($chartData); ?>
-            <!-- Виносимо рейтинг і заголовок в окремий контейнер для центрування. -->
             <div class="poll_heading_b clearfix">
                 <div class="left_rating_b">
                     <a href="javascript:void(0)" class="arrow_rating_top" data-id="<?= $poll->id; ?>"></a><br>
@@ -41,7 +40,6 @@ use common\models\User;
                     <div class="title_poll">
                         <a href="<?= $poll->url ?>"><?= $poll->title; ?></a>
                     </div>
-                    <!-- h3>#DEV1</h3 -->
                 </div>
             </div>
             <div class="middle_name_poll_b clearfix">
@@ -67,19 +65,6 @@ use common\models\User;
                 <span class="item_bottom_poll"><?= Yii::t('poll', 'Користувач'); ?>: <?= User::getUserName($poll->user_id); ?></span>
                 <span class="item_bottom_poll"><?= Yii::t('poll', 'коментарів'); ?>: <?= count($poll->pollComments); ?></span>
                 <span class="item_bottom_poll"><?= Yii::t('poll', 'голосів'); ?>: <?= $poll->countPollOptionsVoters; ?><?= (YII_ENV == 'dev') ? '[#DEV2404b]' : ''; ?></span>
-               <!--<?php if($poll->isOpen()): ?>
-                    <div class="right_poll_status open">
-                        <?= Yii::t('poll', 'Відкрите голосування'); ?>
-                        <span><i class="fa fa-unlock"></i></span>
-                    </div>
-                <?php else: ?>
-                    <div class="right_poll_status closed" title="<?= $poll->countPollOptionsVoters; ?>/<?= $poll->votes_count_close;?>">
-                        <?= Yii::t('poll', 'Закрите голосування'); ?>
-                        <span><i class="fa fa-lock"></i></span>
-                    </div>
-                <?php endif;?> 
-                Це функціонал закритих і відкритих голосувань.
-                -->
             </div>
         </div>
     <?php endforeach?>


### PR DESCRIPTION
### Motivation
- Очистити шаблони опитувань від службових HTML/PHP-коментарів і дебаг-маркерів для підвищення читабельності коду без змін логіки рендерингу.

### Description
- Видалено інлайн HTML/PHP-коментарі з варіантів голосування у `frontend/views/poll/options.php` і `frontend/modules/poll/views/poll/options.php` без зміни форм чи полів.
- Прибрано технічні підказки про розміщення рейтингу/заголовка та debug-маркери `#DEV1` у кількох view-файлах.
- Видалено великий закоментований блок про функціонал відкритих/закритих голосувань у `frontend/widgets/views/polls/_mainPolls.php`.
- Змінені файли: `frontend/views/poll/options.php`, `frontend/views/poll/view.php`, `frontend/views/site/polls/_mainPolls.php`, `frontend/widgets/views/polls/_mainPolls.php`, `frontend/widgets/views/poll-list.php`, `frontend/modules/poll/views/poll/options.php`, `frontend/modules/poll/views/poll/view.php`.

### Testing
- Виконано синтаксичну перевірку змінених PHP-файлів через `php -l` і помилок не виявлено.
- Перевірено, що зміни обмежуються видаленням коментарів і не торкаються бізнес-логіки або форми відправки голосу.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69da5dd6fe00833390496e651712e1a2)