### PR TITLE
Закоментовано дубльовані `fb-root` блоки на сторінках опитувань

### DIFF
--- a/frontend/views/layouts/main/right_column.php
+++ b/frontend/views/layouts/main/right_column.php
@@ -42,11 +42,16 @@ use frontend\widgets\WUserSidebar;
 <?php /* /OLD.adsbygoogle */?>
 		</div>
 		<?= WPollsSidebar::widget(); ?>
-		<?php /* $this->widget('PollsSidebar'); /* */  ?>
-		<div class="social_grey_b">
-			<div id="fb-root"></div>
-			<div id="fb-root"></div>
+			<?php /* $this->widget('PollsSidebar'); /* */  ?>
+			<div class="social_grey_b">
+				<?php
+				// Для девелопера: fb-root блоки повністю вимкнені, щоб не потрапляли у фінальний HTML сторінки.
+				/*
+				<div id="fb-root"></div>
+				<div id="fb-root"></div>
+				*/
+				?>
+			</div>
+	        <?php // Блок з повідомленням про помилки на сайті свідомо видалено. ?>
 		</div>
-        <?php // Блок з повідомленням про помилки на сайті свідомо видалено. ?>
-	</div>
 </div>


### PR DESCRIPTION
### Motivation
- Прибрано дублювання `div id="fb-root"` у шаблоні сайдбару опитувань, щоб заблокувати їхній рендер у фінальному HTML без втрати історичного контексту в коді для розробників.

### Description
- У файлі `frontend/views/layouts/main/right_column.php` два рядки `<div id="fb-root"></div>` переміщено всередину PHP-коментаря (`/* ... */`) з україномовним пояснювальним коментарем для девелопера, щоб вони не виводилися на сторінку.

### Testing
- Запущено `php -l frontend/views/layouts/main/right_column.php` і помилок синтаксису не виявлено; перевірено відмінності через `git diff` та перегляд файлу (`nl`) для підтвердження, що `fb-root` більше не рендериться у шаблоні.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dff23191c48333a762b8a53383c3c4)