### PR TITLE
Виправлено фільтрацію опитувань у сайдбарі для головного домену та піддоменів

### DIFF
--- a/frontend/widgets/WPollsSidebar.php
+++ b/frontend/widgets/WPollsSidebar.php
@@ -54,16 +54,19 @@ class WPollsSidebar extends Widget {
     }
 
     /**
-     * Перевіряє, чи поточний піддомен — nz, щоб обмежити дані лише своїм доменом.
+     * Перевіряє, чи це головний домен (без мовного піддомену).
+     *
+     * На головному домені показуємо всі опитування з усіх мов.
      *
      * @return bool
      */
-    private function isNzSubdomain(): bool
+    private function isMainDomain(): bool
     {
-        $hostParts = explode('.', Yii::$app->request->hostName);
-        $subdomain = strtolower($hostParts[0] ?? '');
+        $host = explode('.', (string) Yii::$app->request->hostName);
+        $subdomain = strtolower($host[0] ?? '');
 
-        return $subdomain === 'nz';
+        // У нашій схемі мовні піддомени мають довжину 2 символи: en, nz, ua, ru тощо.
+        return strlen($subdomain) !== 2;
     }
 
     public function initYiiOne() {
@@ -87,9 +90,9 @@ class WPollsSidebar extends Widget {
     }
 
     public function init() {
-        // Визначаємо ідентифікатор мови з урахуванням поточного піддомену.
+        // Визначаємо режим фільтрації: головний домен = всі мови, піддомен = лише своя мова.
         $languageId = $this->resolveLanguageId();
-        $restrictToLanguageOnly = $this->isNzSubdomain();
+        $showAllLanguages = $this->isMainDomain();
 
         $commentsCountExpression = new Expression('(SELECT COUNT(*) FROM {{%poll_comment}} pc WHERE pc.poll_id = p.id)');
 
@@ -102,14 +105,10 @@ class WPollsSidebar extends Widget {
                 ->limit(Yii::$app->params['POLLS_LIMIT_SIDEBAR'])
                 ->orderBy(['date_add' => SORT_DESC]);
 
-        if ($restrictToLanguageOnly) {
-            // Для nz показуємо лише локальні опитування без глобальних винятків.
+        if (!$showAllLanguages) {
+            // Для будь-якого мовного піддомену показуємо лише локальні опитування,
+            // щоб не підтягувати контент з інших країн/мов (наприклад nz -> en).
             $pollsLastQuery->andWhere(['poll_language_id' => $languageId]);
-        } else {
-            $pollsLastQuery->andWhere(['or',
-                ['poll_language_id' => $languageId],
-                ['show_for_all_languages' => 1],
-            ]);
         }
 
         $this->pollsLast = $pollsLastQuery->all();
@@ -149,14 +148,9 @@ class WPollsSidebar extends Widget {
                 // Та сама межа кількості застосовується і для популярних опитувань.
                 ->limit(Yii::$app->params['POLLS_LIMIT_SIDEBAR']);
 
-        if ($restrictToLanguageOnly) {
-            // Для nz не показуємо опитування «для всіх мов».
+        if (!$showAllLanguages) {
+            // Така сама логіка для популярних: піддомен бачить лише свою мову.
             $pollsPopularQuery->andWhere(['p.poll_language_id' => $languageId]);
-        } else {
-            $pollsPopularQuery->andWhere(['or',
-                ['p.poll_language_id' => $languageId],
-                ['p.show_for_all_languages' => 1],
-            ]);
         }
 
         $this->pollsPopular = $pollsPopularQuery->all();


### PR DESCRIPTION
### Motivation
- Мета змін — виправити логіку відбору опитувань у блоці «Найновіші/Популярні», щоб на головному домені показувалися опитування всіх мов, а на мовних піддоменах — тільки опитування своєї мови.
- Попередня зміна дозволяла на мовних піддоменах потрапляти опитуванням з інших піддоменів (зокрема `nz` на `en`), що потрібно запобігти.

### Description
- Змінено `frontend/widgets/WPollsSidebar.php`: видалено спеціальну перевірку тільки для `nz` і додано загальний метод `isMainDomain()` для розрізнення головного домену та мовних піддоменів. 
- Логіка вибірок для блоків «Найновіші» і «Популярні» тепер показує всі мови на головному домені, а на піддоменах застосовує сувору фільтрацію за `poll_language_id` без підключення `show_for_all_languages` для піддоменів. 
- Додано пояснювальні коментарі в коді; змінений файл — `frontend/widgets/WPollsSidebar.php`; коміт повідомленням українською: `Виправлено фільтрацію опитувань у сайдбарі за доменом` (hash `962f4c2`).

### Testing
- Запущено перевірку синтаксису `php -l frontend/widgets/WPollsSidebar.php`, яка пройшла успішно. 
- Прогнано юніт-тест `php vendor/bin/phpunit tests/ExampleTest.php`, який повернув `OK` (1 тест, 1 ассерт).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1d7a1c9348333ad599d8bad9d51f9)