### PR TITLE
Приховано опитування і пагінацію на /site/actualPolls та /site/myPolls для неавторизованих

### DIFF
--- a/common/models/search/PollSearch.php
+++ b/common/models/search/PollSearch.php
@@ -72,6 +72,14 @@ class PollSearch extends Poll
         }
 
         $query = Poll::find();
+        // Для "Мої опитування" і "Актуальні для вас теми" контент доступний
+        // лише авторизованим користувачам: гостям примусово повертаємо порожній набір.
+        $isRestrictedGuestCategory = Yii::$app->user->isGuest
+            && !empty($params['category'])
+            && in_array($params['category'], ['own', 'actual'], true);
+        if ($isRestrictedGuestCategory) {
+            $query->andWhere('0=1');
+        }
         if(!empty($params['category'])){
             switch ($params['category']){
                 case 'own' :

--- a/frontend/widgets/WPollList.php
+++ b/frontend/widgets/WPollList.php
@@ -146,7 +146,30 @@ HTML;
      */
     public function renderSorter()
     {
+        if ($this->shouldHideRestrictedGuestContent()) {
+            // На закритих для гостей сторінках не показуємо жодні елементи керування списком.
+            return '';
+        }
+
         return $this->render('poll-list-soter', $this->data);
+    }
+
+    public function renderSummary()
+    {
+        if ($this->shouldHideRestrictedGuestContent()) {
+            return '';
+        }
+
+        return parent::renderSummary();
+    }
+
+    public function renderPager()
+    {
+        if ($this->shouldHideRestrictedGuestContent()) {
+            return '';
+        }
+
+        return parent::renderPager();
     }
 
     /**
@@ -178,6 +201,21 @@ HTML;
         $this->data['sort'] = $this->data['sort']
             ?? $this->getRequestString('sort')
             ?? ($this->data['category'] === 'own' ? 'default' : 'desc');
+    }
+
+    /**
+     * Для неавторизованих користувачів сторінки "Актуальні" та "Мої опитування"
+     * мають бути повністю порожніми: без підсумку, сортування і пагінації.
+     */
+    protected function shouldHideRestrictedGuestContent(): bool
+    {
+        if (!Yii::$app->user->isGuest) {
+            return false;
+        }
+
+        $category = $this->data['category'] ?? null;
+
+        return in_array($category, ['own', 'actual'], true);
     }
 
     protected function getRequestString(string $name, ?string $default = null): ?string


### PR DESCRIPTION
### Motivation
- Виправити поведінку сторінок `/site/actualPolls` і `/site/myPolls`, які зараз показують опитування та елементи пагінації гостям, тоді як ці сторінки мають бути доступні лише для авторизованих користувачів.

### Description
- Додано захист у `PollSearch::publishedPolls()` щоб для гостей у категоріях `own` і `actual` запит повертав порожній набір (`AND 0=1`). (файл: `common/models/search/PollSearch.php`).
- Оновлено віджет `WPollList`: додано метод `shouldHideRestrictedGuestContent()` і приховано `summary`, `sorter` та `pager` для гостей на категоріях `own`/`actual`, щоб на сторінках не відображалась служебна інформація і пагінація (файл: `frontend/widgets/WPollList.php`).
- Додано україномовні коментарі поруч із змінами для кращої читабельності та подальшої підтримки.

### Testing
- Запущено статичну перевірку синтаксису: `php -l common/models/search/PollSearch.php` і `php -l frontend/widgets/WPollList.php`, обидва файли пройшли перевірку без синтаксичних помилок.
- Перевірено, що зміни не породжують помилок під час лінтингу файлів, і що сторінки логіки відображення контролюються новими умовами (локальний синтаксичний smoke-test пройдений).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee3be88a388333987b8e795710ea0e)