### PR TITLE
Обмежити блок «Related polls» до тієї ж мови й країни

### DIFF
--- a/frontend/modules/poll/controllers/PollController.php
+++ b/frontend/modules/poll/controllers/PollController.php
@@ -169,6 +169,8 @@ class PollController extends \yii\web\Controller
         }, $poll->tags));
 
         if (!empty($tagIds)) {
+            // Не змішуємо пов'язані опитування між піддоменами:
+            // беремо лише ті, що належать тій самій мові та країні, що й поточне опитування.
             $relatedPolls = Poll::find()
                 ->alias('p')
                 ->select([
@@ -179,6 +181,10 @@ class PollController extends \yii\web\Controller
                 ->innerJoin('{{%poll_tag}} pt', 'pt.poll_id = p.id')
                 ->where(['pt.tag_id' => $tagIds])
                 ->andWhere(['<>', 'p.id', $poll->id])
+                ->andWhere([
+                    'p.poll_language_id' => (int) $poll->poll_language_id,
+                    'p.poll_country_id' => (int) $poll->poll_country_id,
+                ])
                 ->published()
                 ->groupBy('p.id')
                 ->orderBy([


### PR DESCRIPTION
### Motivation
- Блок «Related polls» іноді підтягував опитування з інших піддоменів/локалей, що призводило до змішування мовного й країнового контенту; потрібно обмежити підбір тільки опитуваннями тієї ж мови та країни.

### Description
- У `frontend/modules/poll/controllers/PollController.php` додано фільтрацію в запиті підбору схожих опитувань — тепер запит фільтрує по `p.poll_language_id` і `p.poll_country_id`, а також додано пояснювальні коментарі в коді.

### Testing
- `php -l frontend/modules/poll/controllers/PollController.php` — перевірка синтаксису пройшла без помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69efbbf6e3c083339b41dbc73c8d7613)