### PR TITLE
Локалізація унікальності тегів за `language_id`

### DIFF
--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -545,7 +545,7 @@ class Poll extends ActiveRecord
 
         //filter by poll`s tag
         if($tag){
-            if($tagId = Tag::getTagId($tag)){
+            if($tagId = Tag::getTagId($tag, $this->poll_language_id)){
                 $criteria->with = array(
                     'pollTags'=>array(
                         'select'=>false,
@@ -1076,6 +1076,7 @@ class Poll extends ActiveRecord
         $tagString = Html::encode($tagString);
         $tags = explode(',',$tagString);
         foreach($tags as $tagName){
+            // Створення/перевикористання тегів виконується в межах мови поточного опитування.
             if($tagId = Tag::createNewTag($tagName, $this->poll_language_id)){
                 $pollTag = new PollTag;
                 $pollTag->poll_id = $this->id;
@@ -1297,7 +1298,8 @@ class Poll extends ActiveRecord
         $newTagIds = [];
 
         foreach ($normalizedNames as $tagName) {
-            $tagId = Tag::getTagId($tagName);
+            // Унікальність тегів перевіряємо в межах поточного language_id, щоб не змішувати піддомени.
+            $tagId = Tag::getTagId($tagName, $this->poll_language_id);
             if (!$tagId) {
                 $tagId = Tag::createNewTag($tagName, $this->poll_language_id);
             }

--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -1076,7 +1076,6 @@ class Poll extends ActiveRecord
         $tagString = Html::encode($tagString);
         $tags = explode(',',$tagString);
         foreach($tags as $tagName){
-            // Створення/перевикористання тегів виконується в межах мови поточного опитування.
             if($tagId = Tag::createNewTag($tagName, $this->poll_language_id)){
                 $pollTag = new PollTag;
                 $pollTag->poll_id = $this->id;
@@ -1298,7 +1297,6 @@ class Poll extends ActiveRecord
         $newTagIds = [];
 
         foreach ($normalizedNames as $tagName) {
-            // Унікальність тегів перевіряємо в межах поточного language_id, щоб не змішувати піддомени.
             $tagId = Tag::getTagId($tagName, $this->poll_language_id);
             if (!$tagId) {
                 $tagId = Tag::createNewTag($tagName, $this->poll_language_id);

--- a/common/models/Tag.php
+++ b/common/models/Tag.php
@@ -136,11 +136,23 @@ class Tag extends ActiveRecord
      * return tag`s id by name
      * @tag - tag`s name
      */
-    public static function getTagId($tag)
+    public static function getTagId(string $tag, ?int $languageId = null)
     {
         $result = 0;
-//        $item = Tag::model()->findByAttributes(array('name' => CHtml::encode($tag)));
-        $item = Tag::find()->where(['name' => Html::encode($tag)])->one();
+        $tag = trim(Html::encode($tag));
+
+        if ($tag === "") {
+            return $result;
+        }
+
+        if ($languageId !== null) {
+            // Унікальність тегу тепер локалізована в межах language_id (домен/піддомен).
+            $item = Tag::find()->where(['name' => $tag, 'language_id' => $languageId])->one();
+        } else {
+            // Тимчасовий fallback для legacy-викликів без language_id (зворотна сумісність).
+            $item = Tag::find()->where(['name' => $tag])->one();
+        }
+
         if ($item) {
             $result = $item->id;
         }
@@ -155,7 +167,7 @@ class Tag extends ActiveRecord
         $tagId = 0;
         $name = trim($name);
         if ($name != '') {
-            $tagId = self::getTagId($name);
+            $tagId = self::getTagId($name, (int)$languageId);
             if (!$tagId) {
                 $tag = new Tag;
                 $tag->name = $name;

--- a/common/models/Tag.php
+++ b/common/models/Tag.php
@@ -146,10 +146,8 @@ class Tag extends ActiveRecord
         }
 
         if ($languageId !== null) {
-            // Унікальність тегу тепер локалізована в межах language_id (домен/піддомен).
             $item = Tag::find()->where(['name' => $tag, 'language_id' => $languageId])->one();
         } else {
-            // Тимчасовий fallback для legacy-викликів без language_id (зворотна сумісність).
             $item = Tag::find()->where(['name' => $tag])->one();
         }
 

--- a/console/migrations/m20260429_120000_add_index_tag_name_language_id.php
+++ b/console/migrations/m20260429_120000_add_index_tag_name_language_id.php
@@ -1,0 +1,20 @@
+<?php
+
+use yii\db\Migration;
+
+class m20260429_120000_add_index_tag_name_language_id extends Migration
+{
+    public function safeUp()
+    {
+        $this->createIndex(
+            'idx_tag_name_language_id',
+            '{{%tag}}',
+            ['name', 'language_id']
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->dropIndex('idx_tag_name_language_id', '{{%tag}}');
+    }
+}


### PR DESCRIPTION
### Motivation
- Потрібно уникнути колізій тегів між піддоменами/мовами, щоб один і той самий текст тегу у різних `language_id` розглядався як різні теги.

### Description
- Оновлено сигнатуру `Tag::getTagId` до `getTagId(string $tag, ?int $languageId = null)` і збережено санітизацію через `Html::encode` та `trim`.
- Додано пошук за `['name' => ..., 'language_id' => $languageId]` коли `languageId !== null`, а також тимчасовий fallback без `languageId` для зворотної сумісності.
- У `createNewTag($name, $languageId)` замінено виклик на `self::getTagId($name, (int)$languageId)` щоб перевірка дубля була в межах поточного `language_id`.
- В `common/models/Poll.php` оновлено всі місця виклику: фільтрацію за тегом, `createNewPollTags()` та `syncTags()` щоб використовували `Tag::getTagId(..., $this->poll_language_id)`, та додано короткі коментарі про доменно-локалізовану унікальність тегів.
- Додано міграцію `console/migrations/m20260429_120000_add_index_tag_name_language_id.php`, яка створює індекс `idx_tag_name_language_id` на `tag(name, language_id)` для швидкого та консистентного пошуку.

### Testing
- Виконано синтаксичну перевірку PHP для змінених файлів через `php -l common/models/Tag.php`, `php -l common/models/Poll.php` та `php -l console/migrations/m20260429_120000_add_index_tag_name_language_id.php` — всі перевірки пройшли успішно.
- Жодних інших автоматизованих тестів не запускалося в цьому оновленні.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f264786f548324b1392ef3a5666fa6)