### PR TITLE
Локалізовано вибір тегів в адмінці за мовою опитування

### DIFF
--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -43,8 +43,15 @@ use common\models\Tag;
             ]);
             ?>
 
+    <?php
+    // Показуємо лише теги поточної мови опитування, щоб не змішувати піддомени в адмінці.
+    $tagItems = $model->poll_language_id !== null
+        ? Tag::find()->select(['name'])->where(['language_id' => (int)$model->poll_language_id])->indexBy('name')->orderBy(['name' => SORT_ASC])->column()
+        : [];
+    ?>
+
     <?= $form->field($model, 'tagNames')->widget(Select2::classname(), [
-                'data' => Tag::find()->select(['name'])->indexBy('name')->orderBy(['name' => SORT_ASC])->column(),
+                'data' => $tagItems,
                 'language' => Yii::$app->language,
                 'options' => [
                     'multiple' => true,


### PR DESCRIPTION
### Motivation
- Потрібно уникнути змішування тегів між мовними піддоменами в адмінці; при виборі/створенні тегів для опитування мають показуватися лише теги поточної мови/піддомену.

### Description
- У формі створення/редагування опитування `backend/modules/poll/views/poll/_form.php` джерело даних для Select2 поля `tagNames` обмежено запитом `->where(['language_id' => (int)$model->poll_language_id])`, а при відсутності `poll_language_id` повертається порожній список, щоб не підказувати теги з інших піддоменів.
- Додано коментар у коді, що пояснює причину фільтрації для уникнення змішування піддоменів.
- Збережено наявну логіку створення нових тегів через `syncTags()` → `Tag::createNewTag(..., $this->poll_language_id)`, тому новостворений тег через адмінку автоматично належатиме тій же мові/піддомену, що й опитування.

### Testing
- Виконано синтаксичну перевірку PHP для змінених та релевантних файлів через `php -l backend/modules/poll/views/poll/_form.php`, `php -l common/models/Poll.php` та `php -l common/models/Tag.php` — усі перевірки пройшли успішно.
- Збереження файлу в репозиторії пройшло успішно і створено коміт із повідомленням `Обмежено список тегів в адмінці мовою опитування`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f26f67d05883249e1f900d3dde2aca)