### PR TITLE
Додано індивідуальні метатеги для опитувань з fallback на шаблон

### DIFF
--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -27,6 +27,20 @@ use common\models\Tag;
     
     <?= $form->field($model, 'describe')->widget(ashch\tinymce\TinyMce::class); ?>
 
+
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Мета-теги сторінки опитування</strong></div>
+        <div class="panel-body">
+            <?php // Індивідуальні поля мають пріоритет над шаблоном, але можуть залишатись порожніми. ?>
+            <?= $form->field($model, 'meta_h1')->textInput(['maxlength' => true])
+                ->hint('Кастомний H1 для цього опитування. Якщо порожньо — використається шаблон з налаштувань мови.'); ?>
+            <?= $form->field($model, 'meta_title')->textInput(['maxlength' => true])
+                ->hint('Кастомний title для цього опитування. Якщо порожньо — використається шаблон з налаштувань мови.'); ?>
+            <?= $form->field($model, 'meta_description')->textarea(['rows' => 4, 'class' => 'form-control'])
+                ->hint('Кастомний description для цього опитування. Якщо порожньо — використається шаблон з налаштувань мови.'); ?>
+        </div>
+    </div>
+
     <?= $form->field($model, 'poll_language_id')->widget(Select2::classname(), [
                 'data' => Language::dropDownAllItems(),
                 'language' => Yii::$app->language,

--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -19,12 +19,6 @@ use common\models\Tag;
 
     <?= $form->field($model, 'title')->textInput(['maxlength' => true]) ?>
 
-    <?= $form->field($model, 'status')->textInput() ?>
-
-    <?= $form->field($model, 'votes_count_close')->textInput(['type' => 'number']) ?>
-
-    <?= $form->field($model, 'show_on_slider')->textInput() ?>
-    
     <?= $form->field($model, 'describe')->widget(ashch\tinymce\TinyMce::class); ?>
 
 
@@ -87,6 +81,14 @@ use common\models\Tag;
     <?= $form->field($model, 'result_type')->textInput() ?>    
 
     <?= $form->field($model, 'show_for_all_languages')->textInput() ?>
+
+
+    <?php // Перенесли службові поля вниз форми, щоб SEO-блок був одразу після заголовка. ?>
+    <?= $form->field($model, 'status')->textInput() ?>
+
+    <?= $form->field($model, 'votes_count_close')->textInput(['type' => 'number']) ?>
+
+    <?= $form->field($model, 'show_on_slider')->textInput() ?>
 
     <hr>
     

--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -14,6 +14,9 @@ use yii\db\Expression;
  * @property int $id ID
  * @property string $title Title
  * @property string|null $describe Describe
+ * @property string|null $meta_h1 Meta H1
+ * @property string|null $meta_title Meta title
+ * @property string|null $meta_description Meta description
  * @property int $user_id User
  * @property int $rating Rating
  * @property int $status Status
@@ -110,12 +113,14 @@ class Poll extends ActiveRecord
     {
         return [
             [['title', 'user_id', 'status'], 'required'],
-            [['describe'], 'string'],
+            [['describe', 'meta_description'], 'string'],
             [['user_id', 'rating', 'status', 'views', 'result_type', 'poll_language_id', 'show_for_all_languages', 'poll_sex', 'poll_country_id', 'poll_region_id', 'poll_city_id', 'poll_min_age', 'poll_max_age', 'votes_count_close', 'show_on_slider', 'created_by', 'updated_by', 'created_at', 'updated_at'], 'integer'],
             [['date_add', 'date_update'], 'safe'],
             // Дозволяємо масове присвоєння тегів як масиву назв.
             [['tagNames'], 'safe'],
-            [['title'], 'string', 'max' => 255],
+            // Дозволяємо редагувати індивідуальні мета-поля опитування.
+            [['meta_h1', 'meta_title', 'meta_description'], 'default', 'value' => null],
+            [['title', 'meta_h1', 'meta_title'], 'string', 'max' => 255],
             [['poll_language_id'], 'exist', 'skipOnError' => true, 'targetClass' => Language::class, 'targetAttribute' => ['poll_language_id' => 'id']],
         ];
     }
@@ -129,6 +134,9 @@ class Poll extends ActiveRecord
             'id' => Yii::t('app', 'ID'),
             'title' => Yii::t('app', 'Title'),
             'describe' => Yii::t('app', 'Describe'),
+            'meta_h1' => 'Meta H1',
+            'meta_title' => 'Meta title',
+            'meta_description' => 'Meta description',
             'user_id' => Yii::t('app', 'User'),
             'author.name' => Yii::t('app', 'Author'),
             'rating' => Yii::t('app', 'Rating'),
@@ -1358,21 +1366,30 @@ class Poll extends ActiveRecord
     public function getStaticMeta(): array
     {
         $staticText = $this->getStaticTextRecord();
-        if (!$staticText) {
-            return [
-                'heading' => null,
-                'title' => null,
-                'description' => null,
-            ];
-        }
-
         $replacements = $this->getStaticMetaReplacements();
 
-        return [
-            'heading' => $this->replaceStaticMetaTokens($staticText->heading, $replacements),
-            'title' => $this->replaceStaticMetaTokens($staticText->meta_title, $replacements),
-            'description' => $this->replaceStaticMetaTokens($staticText->meta_description, $replacements),
+        // Спочатку беремо індивідуальні SEO-поля опитування (якщо їх заповнили в адмінці).
+        $meta = [
+            'heading' => $this->replaceStaticMetaTokens($this->meta_h1, $replacements),
+            'title' => $this->replaceStaticMetaTokens($this->meta_title, $replacements),
+            'description' => $this->replaceStaticMetaTokens($this->meta_description, $replacements),
         ];
+
+        // Якщо якесь поле порожнє — м'яко повертаємось до шаблонних значень зі статичних налаштувань мови.
+        $staticText = $this->getStaticTextRecord();
+        if ($staticText) {
+            if ($meta['heading'] === null) {
+                $meta['heading'] = $this->replaceStaticMetaTokens($staticText->heading, $replacements);
+            }
+            if ($meta['title'] === null) {
+                $meta['title'] = $this->replaceStaticMetaTokens($staticText->meta_title, $replacements);
+            }
+            if ($meta['description'] === null) {
+                $meta['description'] = $this->replaceStaticMetaTokens($staticText->meta_description, $replacements);
+            }
+        }
+
+        return $meta;
     }
 
     /**

--- a/console/migrations/m20260506_120000_add_meta_fields_to_poll_table.php
+++ b/console/migrations/m20260506_120000_add_meta_fields_to_poll_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use yii\db\Migration;
+
+class m20260506_120000_add_meta_fields_to_poll_table extends Migration
+{
+    public function safeUp()
+    {
+        // Додаємо окремі SEO-поля для кожного опитування, щоб керувати мета-даними з адмінки.
+        $this->addColumn('{{%poll}}', 'meta_h1', $this->string()->null()->after('describe')->comment('Meta H1'));
+        $this->addColumn('{{%poll}}', 'meta_title', $this->string()->null()->after('meta_h1')->comment('Meta title'));
+        $this->addColumn('{{%poll}}', 'meta_description', $this->text()->null()->after('meta_title')->comment('Meta description'));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('{{%poll}}', 'meta_description');
+        $this->dropColumn('{{%poll}}', 'meta_title');
+        $this->dropColumn('{{%poll}}', 'meta_h1');
+    }
+}


### PR DESCRIPTION
### Motivation
- Додати можливість задавати індивідуальні мета-поля (`H1`, `title`, `description`) для кожного опитування через адмінку замість статичних значень для всіх опитувань. 
- Забезпечити зворотну сумісність: якщо поля в адмінці не заповнені, використовувати існуючий шаблонний механізм з `PollStaticText`. 

### Description
- Додано міграцію `console/migrations/m20260506_120000_add_meta_fields_to_poll_table.php`, яка додає до таблиці `poll` поля `meta_h1`, `meta_title` та `meta_description`. 
- Оновлено модель `common/models/Poll.php`: додано PHPDoc для нових полів, валідаційні правила й `attributeLabels`, а також змінено `getStaticMeta()` щоб спочатку використовувати індивідуальні поля опитування з м'яким fallback на `PollStaticText`. 
- Оновлено форму редагування в адмінці `backend/modules/poll/views/poll/_form.php`, додавши блок для введення `meta_h1`, `meta_title` і `meta_description` з підказками про fallback-поведінку. 

### Testing
- Запущено синтаксичні перевірки PHP: `php -l common/models/Poll.php` пройшов успішно. 
- Запущено синтаксичну перевірку форми адміністратора: `php -l backend/modules/poll/views/poll/_form.php` пройшов успішно. 
- Запущено синтаксичну перевірку міграції: `php -l console/migrations/m20260506_120000_add_meta_fields_to_poll_table.php` пройшов успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb9411239c8324b0dd51c5426a72bb)