### PR TITLE
Додано можливість додавати FAQ-блоки для окремих опитувань

### DIFF
--- a/backend/modules/poll/controllers/PollController.php
+++ b/backend/modules/poll/controllers/PollController.php
@@ -3,7 +3,9 @@
 namespace backend\modules\poll\controllers;
 
 use common\models\Poll;
+use common\models\PollStaticFaq;
 use common\models\search\PollSearch;
+use Yii;
 use yii\web\Controller;
 use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
@@ -71,9 +73,12 @@ class PollController extends Controller
     public function actionCreate()
     {
         $model = new Poll();
+        $faqFormModels = $this->ensureFaqPlaceholders([], null);
 
         if ($this->request->isPost) {
+            $faqFormModels = $this->buildFaqModelsFromPost(null);
             if ($model->load($this->request->post()) && $model->save()) {
+                $this->savePollFaq($model, $faqFormModels);
                 // Після збереження синхронізуємо теги, щоб одразу створити зв'язки.
                 $model->syncTags($model->tagNames);
                 return $this->redirect(['view', 'id' => $model->id]);
@@ -84,6 +89,7 @@ class PollController extends Controller
 
         return $this->render('create', [
             'model' => $model,
+            'faqModels' => $faqFormModels,
         ]);
     }
 
@@ -97,16 +103,79 @@ class PollController extends Controller
     public function actionUpdate($id)
     {
         $model = $this->findModel($id);
+        $faqFormModels = $this->ensureFaqPlaceholders($model->staticFaqs, $model->id);
 
-        if ($this->request->isPost && $model->load($this->request->post()) && $model->save()) {
-            // Оновлюємо теги після збереження, щоб відобразити всі зміни зі сторінки редагування.
-            $model->syncTags($model->tagNames);
-            return $this->redirect(['view', 'id' => $model->id]);
+        if ($this->request->isPost) {
+            $faqFormModels = $this->buildFaqModelsFromPost($model->id);
+            if ($model->load($this->request->post()) && $model->save()) {
+                $this->savePollFaq($model, $faqFormModels);
+                // Оновлюємо теги після збереження, щоб відобразити всі зміни зі сторінки редагування.
+                $model->syncTags($model->tagNames);
+                return $this->redirect(['view', 'id' => $model->id]);
+            }
         }
 
         return $this->render('update', [
             'model' => $model,
+            'faqModels' => $faqFormModels,
         ]);
+    }
+
+    private function buildFaqModelsFromPost(?int $pollId): array
+    {
+        $faqPost = Yii::$app->request->post('PollStaticFaq', []);
+        $faqModels = [];
+        $position = 0;
+
+        foreach ($faqPost as $faqRow) {
+            $question = trim((string) ($faqRow['question'] ?? ''));
+            $answer = trim((string) ($faqRow['answer'] ?? ''));
+            $id = isset($faqRow['id']) ? (int) $faqRow['id'] : null;
+
+            if ($question === '' && $answer === '') {
+                continue;
+            }
+
+            $faqModel = $id ? PollStaticFaq::findOne(['id' => $id, 'poll_id' => $pollId]) : null;
+            if (!$faqModel) {
+                $faqModel = new PollStaticFaq();
+            }
+
+            $faqModel->poll_id = (int) $pollId;
+            $faqModel->question = $question;
+            $faqModel->answer = $answer;
+            $faqModel->position = $position++;
+            $faqModels[] = $faqModel;
+        }
+
+        return $this->ensureFaqPlaceholders($faqModels, $pollId);
+    }
+
+    private function savePollFaq(Poll $model, array $faqModels): void
+    {
+        $savedIds = [];
+        foreach ($faqModels as $faqModel) {
+            if (trim((string) $faqModel->question) === '' || trim((string) $faqModel->answer) === '') {
+                continue;
+            }
+            $faqModel->poll_id = (int) $model->id;
+            $faqModel->save(false);
+            $savedIds[] = $faqModel->id;
+        }
+
+        if (!empty($savedIds)) {
+            PollStaticFaq::deleteAll(['and', ['poll_id' => $model->id], ['not in', 'id', $savedIds]]);
+        } else {
+            PollStaticFaq::deleteAll(['poll_id' => $model->id]);
+        }
+    }
+
+    private function ensureFaqPlaceholders(array $faqModels, ?int $pollId): array
+    {
+        $faqModels = array_values($faqModels);
+        $faqModels[] = new PollStaticFaq(['poll_id' => (int) $pollId]);
+        $faqModels[] = new PollStaticFaq(['poll_id' => (int) $pollId]);
+        return $faqModels;
     }
 
     /**

--- a/backend/modules/poll/controllers/PollController.php
+++ b/backend/modules/poll/controllers/PollController.php
@@ -144,6 +144,8 @@ class PollController extends Controller
             $faqModel->poll_id = (int) $pollId;
             $faqModel->question = $question;
             $faqModel->answer = $answer;
+            // Даємо змогу окремо керувати статичним/динамічним режимом FAQ.
+            $faqModel->is_dynamic = (int) (($faqRow['is_dynamic'] ?? 0) ? 1 : 0);
             $faqModel->position = $position++;
             $faqModels[] = $faqModel;
         }

--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -10,6 +10,7 @@ use common\models\Tag;
 
 /** @var yii\web\View $this */
 /** @var common\models\Poll $model */
+/** @var common\models\PollStaticFaq[] $faqModels */
 /** @var yii\widgets\ActiveForm $form */
 ?>
 
@@ -26,8 +27,30 @@ use common\models\Tag;
                 ->hint('Кастомний H1 для цього опитування. Якщо порожньо — використається шаблон з налаштувань мови.'); ?>
             <?= $form->field($model, 'meta_title')->textInput(['maxlength' => true])
                 ->hint('Кастомний title для цього опитування. Якщо порожньо — використається шаблон з налаштувань мови.'); ?>
-            <?= $form->field($model, 'meta_description')->textarea(['rows' => 4, 'class' => 'form-control'])
+    <?= $form->field($model, 'meta_description')->textarea(['rows' => 4, 'class' => 'form-control'])
                 ->hint('Кастомний description для цього опитування. Якщо порожньо — використається шаблон з налаштувань мови.'); ?>
+        </div>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>FAQ для сторінки опитування</strong></div>
+        <div class="panel-body">
+            <?php foreach ($faqModels as $index => $faqModel): ?>
+                <div class="well">
+                    <?= Html::hiddenInput("PollStaticFaq[$index][id]", $faqModel->id); ?>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <?php // Редактор питання FAQ для мікророзмітки FAQPage. ?>
+                            <?= Html::label('Питання', "poll-faq-question-$index"); ?>
+                            <?= Html::textarea("PollStaticFaq[$index][question]", $faqModel->question, ['class' => 'form-control', 'rows' => 3, 'id' => "poll-faq-question-$index"]); ?>
+                        </div>
+                        <div class="col-md-6">
+                            <?php // Редактор відповіді FAQ у тому ж форматі, що й для тегів. ?>
+                            <?= Html::label('Відповідь', "poll-faq-answer-$index"); ?>
+                            <?= Html::textarea("PollStaticFaq[$index][answer]", $faqModel->answer, ['class' => 'form-control', 'rows' => 3, 'id' => "poll-faq-answer-$index"]); ?>
+                        </div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
         </div>
     </div>
     <?= $form->field($model, 'describe')->widget(ashch\tinymce\TinyMce::class); ?>

--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -47,6 +47,12 @@ use common\models\Tag;
                             <?php // Редактор відповіді FAQ у тому ж форматі, що й для тегів. ?>
                             <?= Html::label('Відповідь', "poll-faq-answer-$index"); ?>
                             <?= Html::textarea("PollStaticFaq[$index][answer]", $faqModel->answer, ['class' => 'form-control', 'rows' => 3, 'id' => "poll-faq-answer-$index"]); ?>
+                            <div class="checkbox" style="margin-top: 10px;">
+                                <label>
+                                    <?= Html::checkbox("PollStaticFaq[$index][is_dynamic]", (int) $faqModel->is_dynamic === 1, ['value' => 1]); ?>
+                                    Динамічний FAQ (дозволити токени на кшталт @title, @votes_total)
+                                </label>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/backend/modules/poll/views/poll/create.php
+++ b/backend/modules/poll/views/poll/create.php
@@ -4,6 +4,7 @@ use yii\helpers\Html;
 
 /** @var yii\web\View $this */
 /** @var common\models\Poll $model */
+/** @var common\models\PollStaticFaq[] $faqModels */
 
 $this->title = Yii::t('app', 'Create Poll');
 $this->params['breadcrumbs'][] = ['label' => Yii::t('app', 'Polls'), 'url' => ['index']];
@@ -13,6 +14,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
     <?= $this->render('_form', [
         'model' => $model,
+        'faqModels' => $faqModels,
     ]) ?>
 
 </div>

--- a/backend/modules/poll/views/poll/update.php
+++ b/backend/modules/poll/views/poll/update.php
@@ -4,6 +4,7 @@ use yii\helpers\Html;
 
 /** @var yii\web\View $this */
 /** @var common\models\Poll $model */
+/** @var common\models\PollStaticFaq[] $faqModels */
 
 $this->title = Yii::t('app', 'Update Poll: {name}', [
     'name' => $model->title,
@@ -16,6 +17,7 @@ $this->params['breadcrumbs'][] = Yii::t('app', 'Update');
 
     <?= $this->render('_form', [
         'model' => $model,
+        'faqModels' => $faqModels,
     ]) ?>
 
 </div>

--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -314,6 +314,35 @@ class Poll extends ActiveRecord
     }
 
     /**
+     * Повертає готові до виводу FAQ: статичні як є, динамічні — з підстановкою токенів.
+     */
+    public function getFaqList(): array
+    {
+        $items = [];
+        $replacements = $this->getStaticInfoReplacements($this->getStaticInfoBlockData());
+        foreach ($this->staticFaqs as $faq) {
+            $question = (string) $faq->question;
+            $answer = (string) $faq->answer;
+
+            if ((int) $faq->is_dynamic === 1) {
+                $question = $this->replaceStaticMetaTokens($question, $replacements) ?? $question;
+                $answer = $this->replaceStaticMetaTokens($answer, $replacements) ?? $answer;
+            }
+
+            if (trim($question) === '' || trim($answer) === '') {
+                continue;
+            }
+
+            $items[] = [
+                'question' => $question,
+                'answer' => $answer,
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
      * Gets query for [[Tags]].
      *
      * @return \yii\db\ActiveQuery|\common\models\query\TagQuery

--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -303,6 +303,17 @@ class Poll extends ActiveRecord
     }
 
     /**
+     * Повертає FAQ, що налаштовані саме для цього опитування.
+     *
+     * @return \yii\db\ActiveQuery
+     */
+    public function getStaticFaqs()
+    {
+        return $this->hasMany(PollStaticFaq::class, ['poll_id' => 'id'])
+            ->orderBy(['position' => SORT_ASC, 'id' => SORT_ASC]);
+    }
+
+    /**
      * Gets query for [[Tags]].
      *
      * @return \yii\db\ActiveQuery|\common\models\query\TagQuery

--- a/common/models/PollStaticFaq.php
+++ b/common/models/PollStaticFaq.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace common\models;
+
+use common\components\ActiveRecord;
+use yii\behaviors\TimestampBehavior;
+
+/**
+ * Модель FAQ для конкретного опитування.
+ */
+class PollStaticFaq extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%poll_static_faq}}';
+    }
+
+    public function behaviors()
+    {
+        return [
+            TimestampBehavior::class,
+        ];
+    }
+
+    public function rules()
+    {
+        return [
+            [['poll_id'], 'required'],
+            [['poll_id', 'position', 'created_at', 'updated_at'], 'integer'],
+            [['question', 'answer'], 'string'],
+            [['question', 'answer'], 'required'],
+            [['poll_id'], 'exist', 'skipOnError' => true, 'targetClass' => Poll::class, 'targetAttribute' => ['poll_id' => 'id']],
+        ];
+    }
+}
+

--- a/common/models/PollStaticFaq.php
+++ b/common/models/PollStaticFaq.php
@@ -27,10 +27,10 @@ class PollStaticFaq extends ActiveRecord
         return [
             [['poll_id'], 'required'],
             [['poll_id', 'position', 'created_at', 'updated_at'], 'integer'],
+            [['is_dynamic'], 'boolean'],
             [['question', 'answer'], 'string'],
             [['question', 'answer'], 'required'],
             [['poll_id'], 'exist', 'skipOnError' => true, 'targetClass' => Poll::class, 'targetAttribute' => ['poll_id' => 'id']],
         ];
     }
 }
-

--- a/console/migrations/m20260512_120000_create_table_poll_static_faq.php
+++ b/console/migrations/m20260512_120000_create_table_poll_static_faq.php
@@ -14,6 +14,8 @@ class m20260512_120000_create_table_poll_static_faq extends Migration
             'poll_id' => $this->integer()->notNull(),
             'question' => $this->text()->notNull(),
             'answer' => $this->text()->notNull(),
+            // Якщо 1 — дозволяємо підстановку токенів (@title, @votes_total, тощо) перед рендером.
+            'is_dynamic' => $this->boolean()->notNull()->defaultValue(0),
             'position' => $this->integer()->notNull()->defaultValue(0),
             'created_at' => $this->integer()->null(),
             'updated_at' => $this->integer()->null(),
@@ -37,4 +39,3 @@ class m20260512_120000_create_table_poll_static_faq extends Migration
         $this->dropTable('{{%poll_static_faq}}');
     }
 }
-

--- a/console/migrations/m20260512_120000_create_table_poll_static_faq.php
+++ b/console/migrations/m20260512_120000_create_table_poll_static_faq.php
@@ -1,0 +1,40 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Створює таблицю FAQ для окремих сторінок опитувань.
+ */
+class m20260512_120000_create_table_poll_static_faq extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%poll_static_faq}}', [
+            'id' => $this->primaryKey(),
+            'poll_id' => $this->integer()->notNull(),
+            'question' => $this->text()->notNull(),
+            'answer' => $this->text()->notNull(),
+            'position' => $this->integer()->notNull()->defaultValue(0),
+            'created_at' => $this->integer()->null(),
+            'updated_at' => $this->integer()->null(),
+        ]);
+
+        $this->createIndex('idx-poll_static_faq-poll_id-position', '{{%poll_static_faq}}', ['poll_id', 'position']);
+        $this->addForeignKey(
+            'fk-poll_static_faq-poll_id',
+            '{{%poll_static_faq}}',
+            'poll_id',
+            '{{%poll}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk-poll_static_faq-poll_id', '{{%poll_static_faq}}');
+        $this->dropTable('{{%poll_static_faq}}');
+    }
+}
+

--- a/frontend/modules/poll/views/poll/view.php
+++ b/frontend/modules/poll/views/poll/view.php
@@ -130,21 +130,6 @@ JS
                                 <?= $this->render('/poll/options', ['poll' => $poll,'chartData'=>$chartData,'bar'=>$bar,'pie'=>$pie]); ?>
                             </div>
                         <?php endif;?>
-                        <?php if (!empty($poll->staticFaqs)): ?>
-                            <div class="info_block tag-faq" itemscope itemtype="https://schema.org/FAQPage">
-                                <h2><?= Yii::t('poll', 'Frequently Asked Questions about the {title}', ['title' => $poll->title]); ?></h2>
-                                <?php foreach ($poll->staticFaqs as $index => $faqItem): ?>
-                                    <div class="faq_entry" itemprop="mainEntity" itemscope itemtype="https://schema.org/Question">
-                                        <button class="faq_question" type="button" aria-expanded="false" aria-controls="faq-answer-<?= $index; ?>">
-                                            <span class="faq_question-text" itemprop="name"><?= Html::encode($faqItem->question); ?></span>
-                                        </button>
-                                        <div class="faq_answer" id="faq-answer-<?= $index; ?>" itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer" hidden>
-                                            <div itemprop="text"><?= nl2br(Html::encode($faqItem->answer)); ?></div>
-                                        </div>
-                                    </div>
-                                <?php endforeach; ?>
-                            </div>
-                        <?php endif; ?>
                     </div>
                     <div class="top_poll_b clearfix bottom_space_for_chart poll_view_footer">
                         <div class="poll_view_tags">
@@ -421,6 +406,24 @@ $date->setTimezone(new DateTimeZone('America/New_York'));
         <?php else: ?>
             <p class="muted"><?= Yii::t('poll', 'У цьому опитуванні ще немає варіантів відповіді.'); ?></p>
         <?php endif; ?>
+    <?php endif; ?>
+
+    <?php $faqList = $poll->getFaqList(); ?>
+    <?php if (!empty($faqList)): ?>
+        <?php // FAQ-блок виносимо вниз info_block, як просили, зі збереженням існуючих стилів tag-faq. ?>
+        <div class="tag-faq" itemscope itemtype="https://schema.org/FAQPage">
+            <h2><?= Yii::t('poll', 'Frequently Asked Questions about the {title}', ['title' => $poll->title]); ?></h2>
+            <?php foreach ($faqList as $index => $faqItem): ?>
+                <div class="faq_entry" itemprop="mainEntity" itemscope itemtype="https://schema.org/Question">
+                    <button class="faq_question" type="button" aria-expanded="false" aria-controls="faq-answer-<?= $index; ?>">
+                        <span class="faq_question-text" itemprop="name"><?= Html::encode($faqItem['question']); ?></span>
+                    </button>
+                    <div class="faq_answer" id="faq-answer-<?= $index; ?>" itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer" hidden>
+                        <div itemprop="text"><?= nl2br(Html::encode($faqItem['answer'])); ?></div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
     <?php endif; ?>
 </div>
 

--- a/frontend/modules/poll/views/poll/view.php
+++ b/frontend/modules/poll/views/poll/view.php
@@ -52,6 +52,27 @@ $this->registerJs(<<<JS
 JS
 , View::POS_END);
 
+$this->registerJs(<<<JS
+(function () {
+    var faqButtons = document.querySelectorAll('.tag-faq .faq_question');
+    faqButtons.forEach(function (button) {
+        button.addEventListener('click', function () {
+            var entry = button.closest('.faq_entry');
+            var answer = document.getElementById(button.getAttribute('aria-controls'));
+            var isOpen = button.getAttribute('aria-expanded') === 'true';
+            button.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+            if (answer) {
+                answer.hidden = isOpen;
+            }
+            if (entry) {
+                entry.classList.toggle('is-open', !isOpen);
+            }
+        });
+    });
+})();
+JS
+, View::POS_READY);
+
 ?>
 <div class="col-md-8">
     <div class="row right_cut_row">
@@ -109,6 +130,21 @@ JS
                                 <?= $this->render('/poll/options', ['poll' => $poll,'chartData'=>$chartData,'bar'=>$bar,'pie'=>$pie]); ?>
                             </div>
                         <?php endif;?>
+                        <?php if (!empty($poll->staticFaqs)): ?>
+                            <div class="info_block tag-faq" itemscope itemtype="https://schema.org/FAQPage">
+                                <h2><?= Yii::t('poll', 'Frequently Asked Questions about the {title}', ['title' => $poll->title]); ?></h2>
+                                <?php foreach ($poll->staticFaqs as $index => $faqItem): ?>
+                                    <div class="faq_entry" itemprop="mainEntity" itemscope itemtype="https://schema.org/Question">
+                                        <button class="faq_question" type="button" aria-expanded="false" aria-controls="faq-answer-<?= $index; ?>">
+                                            <span class="faq_question-text" itemprop="name"><?= Html::encode($faqItem->question); ?></span>
+                                        </button>
+                                        <div class="faq_answer" id="faq-answer-<?= $index; ?>" itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer" hidden>
+                                            <div itemprop="text"><?= nl2br(Html::encode($faqItem->answer)); ?></div>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
                     </div>
                     <div class="top_poll_b clearfix bottom_space_for_chart poll_view_footer">
                         <div class="poll_view_tags">


### PR DESCRIPTION
### Motivation
- Додати можливість додавати власні FAQ-блоки до сторінки опитування за тією ж логікою та з тим самим відображенням, що і для тегів, щоб використовувати існуючі стилі та schema.org мікророзмітку.

### Description
- Додано міграцію `console/migrations/m20260512_120000_create_table_poll_static_faq.php` для таблиці `poll_static_faq` з полями `poll_id`, `question`, `answer`, `position`, timestamp-ами та FK на `poll`.
- Додано модель `common/models/PollStaticFaq.php` з валідаціями та `TimestampBehavior`.
- У `common/models/Poll.php` додано звʼязок `getStaticFaqs()` для отримання FAQ конкретного опитування у заданому порядку.
- Розширено `backend/modules/poll/controllers/PollController.php` логікою підготовки плейсхолдерів, парсингу POST-даних, збереження/видалення FAQ і передачі `faqModels` у представлення create/update.
- Додано UI у backend форму `backend/modules/poll/views/poll/_form.php` (секція «FAQ для сторінки опитування») та передача `faqModels` у `create.php` і `update.php`.
- На frontend сторінці опитування `frontend/modules/poll/views/poll/view.php` додано рендер FAQ-блоку з тією ж HTML-структурою (`info_block tag-faq`, `faq_entry`, `faq_question`, `faq_answer`) і schema.org microdata, а також невеликий JS-скрипт для акордеону (без додаткового CSS).

### Testing
- Перевірено синтаксис змінених файлів командою `php -l` для `backend/modules/poll/controllers/PollController.php`, `backend/modules/poll/views/poll/_form.php`, `frontend/modules/poll/views/poll/view.php`, `common/models/PollStaticFaq.php`, `console/migrations/m20260512_120000_create_table_poll_static_faq.php`, `common/models/Poll.php` — всі пройшли без помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02d0b606488324924f8894d04d8f15)