### PR TITLE
Додати FAQ для опитувань: статичні + індивідуальні, відображення у info_block

### DIFF
--- a/backend/modules/poll/controllers/PollController.php
+++ b/backend/modules/poll/controllers/PollController.php
@@ -2,6 +2,7 @@
 
 namespace backend\modules\poll\controllers;
 
+use common\models\PollFaq;
 use common\models\Poll;
 use common\models\search\PollSearch;
 use yii\web\Controller;
@@ -76,6 +77,7 @@ class PollController extends Controller
             if ($model->load($this->request->post()) && $model->save()) {
                 // Після збереження синхронізуємо теги, щоб одразу створити зв'язки.
                 $model->syncTags($model->tagNames);
+                $this->savePollFaq($model);
                 return $this->redirect(['view', 'id' => $model->id]);
             }
         } else {
@@ -101,6 +103,7 @@ class PollController extends Controller
         if ($this->request->isPost && $model->load($this->request->post()) && $model->save()) {
             // Оновлюємо теги після збереження, щоб відобразити всі зміни зі сторінки редагування.
             $model->syncTags($model->tagNames);
+            $this->savePollFaq($model);
             return $this->redirect(['view', 'id' => $model->id]);
         }
 
@@ -137,5 +140,43 @@ class PollController extends Controller
         }
 
         throw new NotFoundHttpException(Yii::t('app', 'The requested page does not exist.'));
+    }
+
+    /**
+     * Зберігає індивідуальні FAQ для конкретного опитування.
+     */
+    private function savePollFaq(Poll $poll): void
+    {
+        $rows = $this->request->post('PollFaq', []);
+        $position = 0;
+        $savedIds = [];
+
+        foreach ($rows as $row) {
+            $question = trim((string)($row['question'] ?? ''));
+            $answer = trim((string)($row['answer'] ?? ''));
+            $id = isset($row['id']) ? (int)$row['id'] : null;
+
+            if ($question === '' && $answer === '') {
+                continue;
+            }
+
+            $faq = $id ? PollFaq::findOne(['id' => $id, 'poll_id' => $poll->id]) : null;
+            if (!$faq) {
+                $faq = new PollFaq(['poll_id' => $poll->id]);
+            }
+
+            $faq->poll_id = $poll->id;
+            $faq->question = $question;
+            $faq->answer = $answer;
+            $faq->position = $position++;
+            $faq->save(false);
+            $savedIds[] = $faq->id;
+        }
+
+        if (!empty($savedIds)) {
+            PollFaq::deleteAll(['and', ['poll_id' => $poll->id], ['not in', 'id', $savedIds]]);
+        } else {
+            PollFaq::deleteAll(['poll_id' => $poll->id]);
+        }
     }
 }

--- a/backend/modules/poll/controllers/PollController.php
+++ b/backend/modules/poll/controllers/PollController.php
@@ -160,6 +160,11 @@ class PollController extends Controller
                 continue;
             }
 
+            // Не зберігаємо неповні FAQ-рядки, щоб не створювати «невидимі» записи.
+            if ($question === '' || $answer === '') {
+                continue;
+            }
+
             $faq = $id ? PollFaq::findOne(['id' => $id, 'poll_id' => $poll->id]) : null;
             if (!$faq) {
                 $faq = new PollFaq(['poll_id' => $poll->id]);
@@ -169,6 +174,11 @@ class PollController extends Controller
             $faq->question = $question;
             $faq->answer = $answer;
             $faq->position = $position++;
+            // Додатково валідуємо модель перед збереженням навіть для повних рядків.
+            if (!$faq->validate()) {
+                continue;
+            }
+
             $faq->save(false);
             $savedIds[] = $faq->id;
         }

--- a/backend/modules/poll/controllers/PollStaticTextController.php
+++ b/backend/modules/poll/controllers/PollStaticTextController.php
@@ -8,6 +8,7 @@ use yii\web\Response;
 use common\models\Language;
 use common\models\Poll;
 use common\models\PollStaticText;
+use common\models\PollStaticFaq;
 
 /**
  * Керує сторінкою "Статичний текст для опитувань" в адмінці.
@@ -47,7 +48,27 @@ class PollStaticTextController extends Controller
             ]);
         }
 
+        $faqItems = PollStaticFaq::find()->where(['language_id' => $language->id])->orderBy(['position' => SORT_ASC, 'id' => SORT_ASC])->all();
+        $faqFormModels = $faqItems;
+
         if ($model->load(Yii::$app->request->post())) {
+            $faqPost = Yii::$app->request->post('PollStaticFaq', []);
+            $faqFormModels = [];
+            $faqModelsToSave = [];
+            $position = 0;
+            $hasFaqErrors = false;
+            foreach ($faqPost as $faqRow) {
+                $question = trim((string) ($faqRow['question'] ?? ''));
+                $answer = trim((string) ($faqRow['answer'] ?? ''));
+                $id = isset($faqRow['id']) ? (int) $faqRow['id'] : null;
+                if ($question === '' && $answer === '') { continue; }
+                $faqModel = $id ? PollStaticFaq::findOne(['id' => $id, 'language_id' => $language->id]) : null;
+                if (!$faqModel) { $faqModel = new PollStaticFaq(['language_id' => $language->id]); }
+                $faqModel->question = $question; $faqModel->answer = $answer; $faqModel->position = $position++;
+                if (!$faqModel->validate()) { $hasFaqErrors = true; }
+                $faqModelsToSave[] = $faqModel; $faqFormModels[] = $faqModel;
+            }
+
             // Нормалізуємо введення, щоб порожні значення не зберігались як пробіли.
             // Додаємо підтримку HTML-блоку для опису статистики опитування.
             $model->content = trim((string) $model->content);
@@ -55,9 +76,11 @@ class PollStaticTextController extends Controller
             $model->meta_title = trim((string) $model->meta_title);
             $model->meta_description = trim((string) $model->meta_description);
 
-            if (!$model->validate()) {
+            if (!$model->validate() || $hasFaqErrors) {
                 Yii::$app->session->setFlash('error', 'Не вдалося зберегти мета-теги.');
             } else {
+                $transaction = PollStaticText::getDb()->beginTransaction();
+                try {
                 if ($model->isEmpty()) {
                     if (!$model->isNewRecord) {
                         $model->delete();
@@ -69,19 +92,27 @@ class PollStaticTextController extends Controller
                         'model' => $model,
                         'metaTokens' => Poll::getStaticMetaTokens(),
                         'infoTokens' => Poll::getStaticInfoTokens(),
+                        'faqModels' => $faqFormModels,
                     ]);
                 }
 
-                Yii::$app->session->setFlash('success', 'Статичний текст та мета-теги для опитувань оновлено.');
+                foreach ($faqModelsToSave as $faqModel) { $faqModel->save(false); $savedIds[] = $faqModel->id; }
+                    if (!empty($savedIds)) { PollStaticFaq::deleteAll(['and', ['language_id' => $language->id], ['not in', 'id', $savedIds]]); } else { PollStaticFaq::deleteAll(['language_id' => $language->id]); }
+                    $transaction->commit();
+                } catch (\Throwable $exception) { $transaction->rollBack(); throw $exception; }
+                Yii::$app->session->setFlash('success', 'Статичний текст та FAQ для опитувань оновлено.');
                 return $this->redirect(['index']);
             }
         }
 
+        $faqFormModels[] = new PollStaticFaq(['language_id' => $language->id]);
+        $faqFormModels[] = new PollStaticFaq(['language_id' => $language->id]);
         return $this->render('update', [
             'language' => $language,
             'model' => $model,
             'metaTokens' => Poll::getStaticMetaTokens(),
             'infoTokens' => Poll::getStaticInfoTokens(),
+            'faqModels' => $faqFormModels,
         ]);
     }
 

--- a/backend/modules/poll/controllers/PollStaticTextController.php
+++ b/backend/modules/poll/controllers/PollStaticTextController.php
@@ -62,6 +62,8 @@ class PollStaticTextController extends Controller
                 $answer = trim((string) ($faqRow['answer'] ?? ''));
                 $id = isset($faqRow['id']) ? (int) $faqRow['id'] : null;
                 if ($question === '' && $answer === '') { continue; }
+                // Забороняємо збереження неповних FAQ-рядків: питання без відповіді або навпаки.
+                if ($question === '' || $answer === '') { $hasFaqErrors = true; continue; }
                 $faqModel = $id ? PollStaticFaq::findOne(['id' => $id, 'language_id' => $language->id]) : null;
                 if (!$faqModel) { $faqModel = new PollStaticFaq(['language_id' => $language->id]); }
                 $faqModel->question = $question; $faqModel->answer = $answer; $faqModel->position = $position++;
@@ -77,7 +79,7 @@ class PollStaticTextController extends Controller
             $model->meta_description = trim((string) $model->meta_description);
 
             if (!$model->validate() || $hasFaqErrors) {
-                Yii::$app->session->setFlash('error', 'Не вдалося зберегти мета-теги.');
+                Yii::$app->session->setFlash('error', $hasFaqErrors ? 'Перевірте FAQ: кожне запитання повинно мати відповідь.' : 'Не вдалося зберегти мета-теги.');
             } else {
                 $transaction = PollStaticText::getDb()->beginTransaction();
                 try {
@@ -96,6 +98,7 @@ class PollStaticTextController extends Controller
                     ]);
                 }
 
+                $savedIds = [];
                 foreach ($faqModelsToSave as $faqModel) { $faqModel->save(false); $savedIds[] = $faqModel->id; }
                     if (!empty($savedIds)) { PollStaticFaq::deleteAll(['and', ['language_id' => $language->id], ['not in', 'id', $savedIds]]); } else { PollStaticFaq::deleteAll(['language_id' => $language->id]); }
                     $transaction->commit();

--- a/backend/modules/poll/controllers/PollStaticTextController.php
+++ b/backend/modules/poll/controllers/PollStaticTextController.php
@@ -88,23 +88,22 @@ class PollStaticTextController extends Controller
                         $model->delete();
                     }
                 } elseif (!$model->save(false)) {
-                    Yii::$app->session->setFlash('error', 'Не вдалося зберегти мета-теги.');
-                    return $this->render('update', [
-                        'language' => $language,
-                        'model' => $model,
-                        'metaTokens' => Poll::getStaticMetaTokens(),
-                        'infoTokens' => Poll::getStaticInfoTokens(),
-                        'faqModels' => $faqFormModels,
-                    ]);
+                    // Не повертаємось з відкритою транзакцією: кидаємо виняток і відкотимося в catch.
+                    throw new \RuntimeException('Не вдалося зберегти мета-теги.');
                 }
 
                 $savedIds = [];
                 foreach ($faqModelsToSave as $faqModel) { $faqModel->save(false); $savedIds[] = $faqModel->id; }
                     if (!empty($savedIds)) { PollStaticFaq::deleteAll(['and', ['language_id' => $language->id], ['not in', 'id', $savedIds]]); } else { PollStaticFaq::deleteAll(['language_id' => $language->id]); }
                     $transaction->commit();
-                } catch (\Throwable $exception) { $transaction->rollBack(); throw $exception; }
-                Yii::$app->session->setFlash('success', 'Статичний текст та FAQ для опитувань оновлено.');
-                return $this->redirect(['index']);
+                } catch (\Throwable $exception) {
+                    $transaction->rollBack();
+                    Yii::$app->session->setFlash('error', 'Не вдалося зберегти мета-теги.');
+                }
+                if (!Yii::$app->session->hasFlash('error')) {
+                    Yii::$app->session->setFlash('success', 'Статичний текст та FAQ для опитувань оновлено.');
+                    return $this->redirect(['index']);
+                }
             }
         }
 

--- a/backend/modules/poll/views/poll-static-text/update.php
+++ b/backend/modules/poll/views/poll-static-text/update.php
@@ -8,6 +8,7 @@ use yii\widgets\ActiveForm;
 /** @var common\models\PollStaticText $model */
 /** @var array $metaTokens */
 /** @var array $infoTokens */
+/** @var common\models\PollStaticFaq[] $faqModels */
 
 $this->title = 'Статичний текст для опитувань: ' . $language->title;
 $this->params['breadcrumbs'][] = ['label' => 'Статичний текст для опитувань', 'url' => ['index']];
@@ -60,6 +61,31 @@ $this->params['breadcrumbs'][] = $language->title;
                 <?= $form->field($model, 'meta_description')
                     ->textarea(['rows' => 4, 'class' => 'form-control'])
                     ->hint('Власний мета-опис. Порожнє значення повертає автоматичний опис.'); ?>
+            </div>
+        </div>
+
+        
+        <div class="panel panel-default">
+            <div class="panel-heading"><strong>FAQ для сторінки опитування (статичний)</strong></div>
+            <div class="panel-body">
+                <p>Ці FAQ додаються для всіх опитувань обраної підмови. Доступні ті самі змінні, що і вище.</p>
+                <div class="faq-items">
+                    <?php foreach ($faqModels as $index => $faqModel): ?>
+                        <div class="faq-item well">
+                            <?= Html::hiddenInput("PollStaticFaq[$index][id]", $faqModel->id); ?>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <?= Html::label('Питання', "poll-static-faq-question-$index"); ?>
+                                    <?= Html::textarea("PollStaticFaq[$index][question]", $faqModel->question, ['id'=>"poll-static-faq-question-$index", 'class'=>'form-control', 'rows'=>3]); ?>
+                                </div>
+                                <div class="col-md-6">
+                                    <?= Html::label('Відповідь', "poll-static-faq-answer-$index"); ?>
+                                    <?= Html::textarea("PollStaticFaq[$index][answer]", $faqModel->answer, ['id'=>"poll-static-faq-answer-$index", 'class'=>'form-control', 'rows'=>3]); ?>
+                                </div>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
             </div>
         </div>
 

--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -7,6 +7,7 @@ use kartik\select2\Select2;
 use common\models\Language;
 use common\models\User;
 use common\models\Tag;
+use common\models\PollFaq;
 
 /** @var yii\web\View $this */
 /** @var common\models\Poll $model */
@@ -31,6 +32,32 @@ use common\models\Tag;
         </div>
     </div>
     <?= $form->field($model, 'describe')->widget(ashch\tinymce\TinyMce::class); ?>
+    <?php
+    // Завантажуємо індивідуальні FAQ для цього опитування (або показуємо 2 порожні рядки для нового).
+    $pollFaqItems = $model->isNewRecord ? [] : PollFaq::find()->where(['poll_id' => $model->id])->orderBy(['position' => SORT_ASC, 'id' => SORT_ASC])->all();
+    $pollFaqItems[] = new PollFaq();
+    $pollFaqItems[] = new PollFaq();
+    ?>
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Індивідуальний FAQ для цього опитування</strong></div>
+        <div class="panel-body">
+            <?php foreach ($pollFaqItems as $index => $faqItem): ?>
+                <div class="well">
+                    <?= Html::hiddenInput("PollFaq[$index][id]", $faqItem->id); ?>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <?= Html::label('Питання', "poll-faq-question-$index"); ?>
+                            <?= Html::textarea("PollFaq[$index][question]", $faqItem->question, ['id' => "poll-faq-question-$index", 'class' => 'form-control', 'rows' => 3]); ?>
+                        </div>
+                        <div class="col-md-6">
+                            <?= Html::label('Відповідь', "poll-faq-answer-$index"); ?>
+                            <?= Html::textarea("PollFaq[$index][answer]", $faqItem->answer, ['id' => "poll-faq-answer-$index", 'class' => 'form-control', 'rows' => 3]); ?>
+                        </div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
     <?= $form->field($model, 'poll_language_id')->widget(Select2::classname(), [
                 'data' => Language::dropDownAllItems(),
                 'language' => Yii::$app->language,

--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -1476,6 +1476,32 @@ class Poll extends ActiveRecord
         return $this->replaceStaticMetaTokens($staticText->content, $replacements);
     }
 
+
+    /**
+     * Повертає об'єднаний FAQ: спершу статичний (для підмови), потім індивідуальний для опитування.
+     */
+    public function getFaqList(): array
+    {
+        $data = $this->getStaticInfoBlockData();
+        $replacements = $this->getStaticInfoReplacements($data);
+
+        $items = [];
+        $staticFaq = PollStaticFaq::find()->where(['language_id' => (int)$this->poll_language_id])->orderBy(['position' => SORT_ASC, 'id' => SORT_ASC])->all();
+        foreach ($staticFaq as $faq) {
+            $q = strtr((string)$faq->question, $replacements);
+            $a = strtr((string)$faq->answer, $replacements);
+            if (trim($q) !== '' && trim($a) !== '') { $items[] = ['question' => $q, 'answer' => $a]; }
+        }
+
+        $pollFaq = PollFaq::find()->where(['poll_id' => (int)$this->id])->orderBy(['position' => SORT_ASC, 'id' => SORT_ASC])->all();
+        foreach ($pollFaq as $faq) {
+            $q = strtr((string)$faq->question, $replacements);
+            $a = strtr((string)$faq->answer, $replacements);
+            if (trim($q) !== '' && trim($a) !== '') { $items[] = ['question' => $q, 'answer' => $a]; }
+        }
+
+        return $items;
+    }
     /**
      * Повертає обчислені дані для блоку статистики опитування.
      */

--- a/common/models/PollFaq.php
+++ b/common/models/PollFaq.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace common\models;
+
+use common\components\ActiveRecord;
+use yii\behaviors\TimestampBehavior;
+
+/**
+ * Індивідуальний FAQ для конкретного опитування.
+ */
+class PollFaq extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%poll_faq}}';
+    }
+
+    public function behaviors()
+    {
+        return [TimestampBehavior::class];
+    }
+
+    public function rules()
+    {
+        return [
+            [['poll_id', 'question', 'answer'], 'required'],
+            [['poll_id', 'position', 'created_at', 'updated_at'], 'integer'],
+            [['question', 'answer'], 'string'],
+            [['poll_id'], 'exist', 'skipOnError' => true, 'targetClass' => Poll::class, 'targetAttribute' => ['poll_id' => 'id']],
+        ];
+    }
+}

--- a/common/models/PollStaticFaq.php
+++ b/common/models/PollStaticFaq.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace common\models;
+
+use common\components\ActiveRecord;
+use yii\behaviors\TimestampBehavior;
+
+/**
+ * Статичний FAQ для сторінки опитування (на рівні мови/піддомену).
+ */
+class PollStaticFaq extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%poll_static_faq}}';
+    }
+
+    public function behaviors()
+    {
+        return [TimestampBehavior::class];
+    }
+
+    public function rules()
+    {
+        return [
+            [['language_id', 'question', 'answer'], 'required'],
+            [['language_id', 'position', 'created_at', 'updated_at'], 'integer'],
+            [['question', 'answer'], 'string'],
+            [['language_id'], 'exist', 'skipOnError' => true, 'targetClass' => Language::class, 'targetAttribute' => ['language_id' => 'id']],
+        ];
+    }
+}

--- a/console/migrations/m20260512_120000_create_poll_faq_tables.php
+++ b/console/migrations/m20260512_120000_create_poll_faq_tables.php
@@ -1,0 +1,42 @@
+<?php
+
+use yii\db\Migration;
+
+class m20260512_120000_create_poll_faq_tables extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%poll_static_faq}}', [
+            'id' => $this->primaryKey(),
+            'language_id' => $this->integer()->notNull(),
+            'question' => $this->text()->notNull(),
+            'answer' => $this->text()->notNull(),
+            'position' => $this->integer()->notNull()->defaultValue(0),
+            'created_at' => $this->integer()->null(),
+            'updated_at' => $this->integer()->null(),
+        ]);
+        $this->createIndex('idx-poll_static_faq-language_id-position', '{{%poll_static_faq}}', ['language_id', 'position']);
+        $this->addForeignKey('fk-poll_static_faq-language_id', '{{%poll_static_faq}}', 'language_id', '{{%language}}', 'id', 'CASCADE', 'CASCADE');
+
+        $this->createTable('{{%poll_faq}}', [
+            'id' => $this->primaryKey(),
+            'poll_id' => $this->integer()->notNull(),
+            'question' => $this->text()->notNull(),
+            'answer' => $this->text()->notNull(),
+            'position' => $this->integer()->notNull()->defaultValue(0),
+            'created_at' => $this->integer()->null(),
+            'updated_at' => $this->integer()->null(),
+        ]);
+        $this->createIndex('idx-poll_faq-poll_id-position', '{{%poll_faq}}', ['poll_id', 'position']);
+        $this->addForeignKey('fk-poll_faq-poll_id', '{{%poll_faq}}', 'poll_id', '{{%poll}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk-poll_faq-poll_id', '{{%poll_faq}}');
+        $this->dropTable('{{%poll_faq}}');
+
+        $this->dropForeignKey('fk-poll_static_faq-language_id', '{{%poll_static_faq}}');
+        $this->dropTable('{{%poll_static_faq}}');
+    }
+}

--- a/frontend/modules/poll/views/poll/view.php
+++ b/frontend/modules/poll/views/poll/view.php
@@ -395,10 +395,10 @@ $date->setTimezone(new DateTimeZone('America/New_York'));
             <?php foreach ($faqList as $faqIndex => $faqItem): ?>
                 <div class="faq_entry" itemprop="mainEntity" itemscope itemtype="https://schema.org/Question">
                     <button class="faq_question" type="button" aria-expanded="false" aria-controls="poll-faq-answer-<?= $faqIndex; ?>">
-                        <span class="faq_question-text" itemprop="name"><?= $faqItem['question']; ?></span>
+                        <span class="faq_question-text" itemprop="name"><?= Html::encode($faqItem['question']); ?></span>
                     </button>
                     <div class="faq_answer" id="poll-faq-answer-<?= $faqIndex; ?>" hidden itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer">
-                        <div itemprop="text"><?= $faqItem['answer']; ?></div>
+                        <div itemprop="text"><?= nl2br(Html::encode($faqItem['answer'])); ?></div>
                     </div>
                 </div>
             <?php endforeach; ?>

--- a/frontend/modules/poll/views/poll/view.php
+++ b/frontend/modules/poll/views/poll/view.php
@@ -328,6 +328,7 @@ $date->setTimezone(new DateTimeZone('America/New_York'));
     // Дозволяємо перевизначити стандартний блок статистики через адмінку.
     $infoBlockData = $poll->getStaticInfoBlockData();
     $customInfoBlock = $poll->getStaticInfoBlock($infoBlockData);
+    $faqList = $poll->getFaqList();
     ?>
     <?php if ($customInfoBlock !== null): ?>
         <?= $customInfoBlock; ?>
@@ -386,6 +387,24 @@ $date->setTimezone(new DateTimeZone('America/New_York'));
             <p class="muted"><?= Yii::t('poll', 'У цьому опитуванні ще немає варіантів відповіді.'); ?></p>
         <?php endif; ?>
     <?php endif; ?>
+
+    <?php if (!empty($faqList)): ?>
+        <?php // Рендеримо один спільний FAQ-блок: статичний + індивідуальний для цього опитування. ?>
+        <div class="tag-faq" itemscope itemtype="https://schema.org/FAQPage">
+            <h2><?= Yii::t('poll', 'FAQ'); ?></h2>
+            <?php foreach ($faqList as $faqIndex => $faqItem): ?>
+                <div class="faq_entry" itemprop="mainEntity" itemscope itemtype="https://schema.org/Question">
+                    <button class="faq_question" type="button" aria-expanded="false" aria-controls="poll-faq-answer-<?= $faqIndex; ?>">
+                        <span class="faq_question-text" itemprop="name"><?= $faqItem['question']; ?></span>
+                    </button>
+                    <div class="faq_answer" id="poll-faq-answer-<?= $faqIndex; ?>" hidden itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer">
+                        <div itemprop="text"><?= $faqItem['answer']; ?></div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
 </div>
 
 
@@ -409,6 +428,7 @@ $pollId = $poll->id;
 $pollTitle = Json::encode($poll->title);
 
 $js = <<<JS
+(function(){var faqButtons=document.querySelectorAll('.tag-faq .faq_question');faqButtons.forEach(function(button){button.addEventListener('click',function(){var entry=button.closest('.faq_entry');if(!entry){return;}var isOpen=entry.classList.toggle('is-open');button.setAttribute('aria-expanded',isOpen?'true':'false');var answerId=button.getAttribute('aria-controls');var answer=answerId?document.getElementById(answerId):null;if(answer){answer.hidden=!isOpen;}});});})();
 var maxLength = jQuery('#answer_text').attr('maxlength');
 jQuery('#answer_text').on('keyup', function () {
     var curLength = jQuery('#answer_text').val().length;


### PR DESCRIPTION
### Motivation
- Додати можливість створювати статичні FAQ-блоки для сторінки «Статичний текст для опитувань» з підтримкою змінних, які застосовуються для всіх опитувань підмови (піддоменів). 
- Додати можливість створювати індивідуальні FAQ для кожного опитування, які доповнюють статичний блок і виводяться підряд у одному спільному FAQ-блоці внизу сторінки опитувань (`<div class="info_block">`).

### Description
- Додано нові моделі `PollStaticFaq` та `PollFaq` у `common/models/` для зберігання відповідно статичних FAQ по `language_id` і індивідуальних FAQ по `poll_id` і створено міграцію `console/migrations/m20260512_120000_create_poll_faq_tables.php` для таблиць `poll_static_faq` та `poll_faq` з індексами й FK. 
- Розширено адмінку: контролер `PollStaticTextController` і view `backend/modules/poll/views/poll-static-text/update.php` тепер підтримують редагування/збереження статичних FAQ з валідацією та порядком; у формі створено заповнювачі для швидкого додавання рядків. 
- Додано підтримку індивідуальних FAQ у CRUD опитувань: у форму `backend/modules/poll/views/poll/_form.php` додано блок редагування індивідуального FAQ, а `backend/modules/poll/controllers/PollController.php` зберігає їх через приватний метод `savePollFaq`. 
- На моделі `Poll` додано `getFaqList()` для об'єднання статичних FAQ (першими) та індивідуальних FAQ із підстановкою змінних, а фронтенд `frontend/modules/poll/views/poll/view.php` виводить один спільний FAQ-блок всередині `<div class="info_block">`, використовуючи наявні стилі (`tag-faq`, `faq_entry`, `faq_question`, `faq_answer`) та простий JS-акордеон для розкриття відповідей. 

### Testing
- Прогнано синтаксичні перевірки `php -l` для змінених контролерів, моделей та view-файлів (`backend/modules/poll/controllers/PollStaticTextController.php`, `backend/modules/poll/controllers/PollController.php`, `backend/modules/poll/views/poll-static-text/update.php`, `backend/modules/poll/views/poll/_form.php`, `frontend/modules/poll/views/poll/view.php`, `common/models/Poll.php`) — всі перевірки пройшли без помилок. 
- Додано міграцію, яку потрібно застосувати у середовищі (наприклад через `yii migrate`) перед використанням функціональності; автоматизованих unit/integration тестів не додавалось у цьому PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a037a55c04c83249affa31611a9acf8)