### PR TITLE
Оновлено дизайн хедера у сучасному стилі

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,15 +9,15 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo" aria-label="Referendum.social">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
-                <a href="/" class="logo">
+                <a href="/" class="logo" aria-label="Referendum.social">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <br>
@@ -28,12 +28,13 @@ use frontend\widgets\WSearchForm;
             <?php endif; ?>
 
             <div class="right_header_b">
+                <?php // Групуємо керування мовою та пошуком у візуально цілісний блок хедера. ?>
                 <?= WLanguageSelector::widget(); ?>
                 <br>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>
-                <div class="search_b">
+                <div class="search_b" role="search">
                     <form method="post" action="/site/search" name="HeaderSearch">
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
                         <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -126,35 +126,53 @@ a:hover {
     max-width: 970px;
 }
 .header {
-    min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
+    min-height: 104px;
+    background: linear-gradient(180deg, rgba(10, 99, 47, 0.93) 0%, rgba(7, 83, 39, 0.95) 100%), url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+}
+/* Робимо структуру хедера більш сучасною через flex без зміни функціоналу. */
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 12px 0;
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    display: inline-flex;
+    flex-direction: column;
     text-decoration: none;
 }
 .sub_text_logo {
-    color: #fff;
+    color: #e9fff0;
     display: inline-block;
     margin-left: 37px;
     line-height: 24px;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }
 .right_header_b {
-    float: right;
-    text-align: right;
-    margin-top: 13px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(1px);
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
+    min-width: 142px;
+    height: 32px;
+    line-height: 30px;
     border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    border-radius: 7px;
+    background: #e9f1ef;
+    color: #0d4f26;
+    padding: 0 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
 }
 .language_select:hover,
 .language_select:focus {
@@ -166,13 +184,14 @@ a.logo, div.logo {
 .search_input {
     display: inline-block;
     width: 300px;
-    height: 32px;
+    height: 36px;
     border: 2px solid #147536;
-    background: #f0f4f4;
-    border-radius: 4px;
+    background: #f7fbfa;
+    border-radius: 8px;
     padding-left: 12px;
     color: #565656;
     outline: none;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 .search_input:hover,
 .search_input:focus {
@@ -185,12 +204,27 @@ a.logo, div.logo {
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
+    top: 12px;
     right: 10px;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+@media (max-width: 767px) {
+    .header_row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .right_header_b {
+        width: 100%;
+        align-items: stretch;
+    }
+
+    .search_input {
+        width: 100%;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Оновити візуальний вигляд хедера на більш сучасний, не порушуючи існуючий функціонал (логотип, підпис, перемикач мов, пошук) та зберегти розміри логотипа `184x58`.
- Покращити адаптивність і мінімально підвищити доступність без зміни бізнес-логіки сторінки.

### Description
- Змінено розмітку в `frontend/views/layouts/main/header.php`: додано обгортку `header_row`, `aria-label` для логотипа, коментарі в коді та `role="search"` для блоку пошуку. 
- Оновлено стилі в `frontend/web/css/main.css`: замінено фон на градієнт із тінню, переведено хедер на `flex` через `.header_row`, додано стилі для `.right_header_b`, `.language_select` та `.search_input` з сучасними радіусами й тенями, а також медіа-правила для мобільних екранів.
- Збережено існуючі елементи й поведінку (включно з іконкою пошуку та формою), додано лише візуальні й структурні покращення та коментарі у файлах.

### Testing
- Запущена перевірка синтаксису PHP `php -l frontend/views/layouts/main/header.php` — пройшло успішно.
- Згенеровано `git diff` для файлів `frontend/views/layouts/main/header.php` та `frontend/web/css/main.css`, та зміни закомічено (усі перевірки пройшли успішно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0a2006018c832488004eb111f45fae)