### PR TITLE
Осучаснення хедера зі збереженням функціоналу

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,15 +9,15 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo header_logo" aria-label="referendum.social logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
-                <a href="/" class="logo">
+                <a href="/" class="logo header_logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <br>
@@ -27,9 +27,9 @@ use frontend\widgets\WSearchForm;
                 </a>
             <?php endif; ?>
 
-            <div class="right_header_b">
+            <div class="right_header_b" aria-label="header controls">
                 <?= WLanguageSelector::widget(); ?>
-                <br>
+                <?php // Прибираємо застарілий перенос і переходимо на керування відступами через CSS. ?>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -140,6 +140,9 @@ a:hover {
     justify-content: space-between;
     gap: 20px;
     padding: 12px 0;
+    /* Нівелюємо дефолтні негативні відступи bootstrap .row, щоб уникнути горизонтального скролу. */
+    margin-left: 0;
+    margin-right: 0;
 }
 a.logo, div.logo {
     margin-top: 0;
@@ -201,6 +204,7 @@ a.logo, div.logo {
     outline: none;
     box-shadow: inset 0 1px 2px rgba(17, 74, 39, 0.09);
     transition: all 0.2s ease;
+    box-sizing: border-box;
 }
 .search_input:hover,
 .search_input:focus {
@@ -222,17 +226,47 @@ a.logo, div.logo {
     background: url(/img/layout/search_icon_hover.png);
 }
 @media (max-width: 767px) {
+    .header {
+        /* На мобільному спрощуємо тінь, щоб шапка виглядала легше. */
+        box-shadow: 0 4px 12px rgba(9, 51, 25, 0.16);
+    }
     .header_row {
         flex-direction: column;
         align-items: flex-start;
+        gap: 12px;
+        padding: 10px 0;
+    }
+    .header_logo {
+        width: 100%;
+    }
+    .sub_text_logo {
+        /* Прибираємо великий зсув підпису, який ламає композицію на вузьких екранах. */
+        margin-left: 0;
+        line-height: 20px;
     }
     .right_header_b {
         width: 100%;
         align-items: flex-start;
+        gap: 8px;
     }
+    .language_select,
+    .search_b,
     .search_input {
         width: 100%;
-        min-width: 260px;
+        min-width: 0;
+        max-width: 100%;
+    }
+    .language_select {
+        height: 34px;
+        line-height: 32px;
+    }
+    .search_input {
+        height: 38px;
+        padding-right: 38px;
+    }
+    .search_btn {
+        top: 12px;
+        right: 12px;
     }
 }
 .sub_header_slider_b {

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -127,70 +127,113 @@ a:hover {
 }
 .header {
     min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
+    /* Осучаснюємо фон: залишаємо фірмовий зелений настрій, але додаємо глибину через градієнт. */
+    background:
+        linear-gradient(135deg, rgba(10, 82, 38, 0.93) 0%, rgba(22, 117, 54, 0.95) 58%, rgba(38, 154, 80, 0.9) 100%),
+        url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
+    box-shadow: 0 10px 24px rgba(9, 51, 25, 0.15);
+}
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 12px 0;
 }
 a.logo, div.logo {
-    margin-top: 10px;
+    margin-top: 0;
     display: inline-block;
     text-decoration: none;
+}
+.header_logo img {
+    /* Залишаємо незмінні візуальні габарити логотипа, як вимагалось. */
+    width: 184px;
+    height: 58px;
 }
 .sub_text_logo {
     color: #fff;
     display: inline-block;
     margin-left: 37px;
     line-height: 24px;
+    letter-spacing: 0.2px;
 }
 .right_header_b {
-    float: right;
+    float: none;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
     text-align: right;
-    margin-top: 13px;
+    margin-top: 0;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
-    border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    width: 160px;
+    height: 36px;
+    line-height: 34px;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    border-radius: 10px;
+    background: rgba(238, 248, 244, 0.93);
+    padding: 0 12px;
+    margin-bottom: 0;
+    font-size: 13px;
+    transition: all 0.2s ease;
 }
 .language_select:hover,
 .language_select:focus {
     background: #fff;
+    border-color: #fff;
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.25);
 }
 .search_b {
     position: relative;
 }
 .search_input {
     display: inline-block;
-    width: 300px;
-    height: 32px;
-    border: 2px solid #147536;
-    background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    width: 320px;
+    height: 40px;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    background: rgba(241, 247, 245, 0.95);
+    border-radius: 12px;
+    padding: 0 40px 0 14px;
     color: #565656;
     outline: none;
+    box-shadow: inset 0 1px 2px rgba(17, 74, 39, 0.09);
+    transition: all 0.2s ease;
 }
 .search_input:hover,
 .search_input:focus {
     background: #fff;
     color: #000;
-    border-color: #3ac469;
+    border-color: #b4edc8;
+    box-shadow: 0 0 0 3px rgba(153, 236, 186, 0.25);
 }
 .search_btn {
     position: absolute;
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 14px;
+    right: 14px;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+@media (max-width: 767px) {
+    .header_row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .right_header_b {
+        width: 100%;
+        align-items: flex-start;
+    }
+    .search_input {
+        width: 100%;
+        min-width: 260px;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Оновити візуальне оформлення хедера, зберігши існуючий функціонал і розміри логотипа (184×58) та гармонію з загальним стилем сайту.
- Покращити мобільну адаптацію, читабельність і стани фокусу/hover для елементів керування без зміни бізнес-логіки.

### Description
- Перебудовано розмітку хедера: додано контейнер `header_row` для гнучкого розташування елементів і клас `header_logo` для логотипа, а також `aria-label` для доступності у `frontend/views/layouts/main/header.php`.
- Прибрано застарілий `<br>` між логотипом та іншими елементами і замінено відступи на контрольовані через CSS, з додатковими коментарями у коді.
- Оновлено стилі у `frontend/web/css/main.css`: градієнтний фон з тінню, сучасніші форми для `select` та поля пошуку, плавні переходи для `hover/focus`, округлення кутів та адаптивні правила (`@media`) для мобільних екранів.
- Забезпечено збереження візуальних габаритів логотипа шляхом явного вказання `width: 184px; height: 58px;` у CSS та додано мінімальні пояснювальні коментарі поруч зі змінами.

### Testing
- Запуск синтаксичної перевірки `php -l frontend/views/layouts/main/header.php` — перевірка пройдена без синтаксичних помилок.
- Перевірено різницю файлів для контролю внесених змін шляхом порівняння змін у `frontend/views/layouts/main/header.php` та `frontend/web/css/main.css`, і стилі коректно інтегровані у наявний CSS-файл.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0a2006018c832488004eb111f45fae)