### PR TITLE
Осучаснено хедер: flex‑макет і покращена адаптивність

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,9 +9,9 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -130,9 +130,17 @@ a:hover {
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
 }
+/* Осучаснюємо хедер: переводимо layout на flex для кращої адаптивності. */
+.header .header_row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
 a.logo, div.logo {
     margin-top: 10px;
-    display: inline-block;
+    display: inline-flex;
+    flex-direction: column;
     text-decoration: none;
 }
 .sub_text_logo {
@@ -142,19 +150,22 @@ a.logo, div.logo {
     line-height: 24px;
 }
 .right_header_b {
-    float: right;
-    text-align: right;
     margin-top: 13px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
+    min-width: 132px;
+    width: auto;
     height: 24px;
     line-height: 22px;
     border: 1px solid #147536;
     border-radius: 2px;
     background: #dce6e4;
-    margin-bottom: 10px;
+    margin-bottom: 0;
 }
 .language_select:hover,
 .language_select:focus {
@@ -3543,6 +3554,32 @@ a.pass_on_main_page {
     }
 }
 @media (max-width: 768px) {
+    /* Робимо хедер читабельним на планшетах і телефонах без втрати функціоналу. */
+    .header {
+        min-height: auto;
+        padding-bottom: 12px;
+    }
+    .header .header_row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+    .sub_text_logo {
+        margin-left: 36px;
+        line-height: 20px;
+    }
+    .right_header_b {
+        width: 100%;
+        margin-top: 0;
+        align-items: stretch;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+    }
+    .search_b {
+        width: 100%;
+    }
     .related-polls-title {
         font-size: 20px;
     }
@@ -3641,6 +3678,14 @@ a.pass_on_main_page {
     }
 }
 @media (max-width: 480px) {
+    .logo img {
+        width: 184px;
+        height: 58px;
+        max-width: 100%;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+    }
     .related-polls-item {
         gap: 10px;
         padding: 8px 10px;


### PR DESCRIPTION
### Motivation
- Оновити хедер до сучасного, адаптивного макету без втрати поточного функціоналу і збереження розміру логотипа на мобільних екранax.
- Поліпшити вигляд і читабельність хедера на планшетах і телефонах, зберігши стилі й елементи інтерфейсу сайту.

### Description
- Додано клас `header_row` у `frontend/views/layouts/main/header.php` і прибрано inline‑стиль з блоку логотипа, зберігаючи існуючі коментарі в коді.
- Оновлено `frontend/web/css/main.css` — хедер переведено на `flex` через `.header .header_row`, `.logo` зроблено `inline-flex`, `.right_header_b` став flex‑контейнером, а `language_select` отримав `min-width` і гнучку ширину.
- Додано адаптивні правила у `@media (max-width: 768px)` та `@media (max-width: 480px)` для колонової верстки, розтягнення селектора і поля пошуку на 100% та явного обмеження розміру логотипа `184x58` на малих екранах.
- Вирівняно дрібні відступи (зокрема `margin-bottom: 0`) у кількох місцях для узгодженого відображення після переходу на flex.

### Testing
- Запущено `php -l frontend/views/layouts/main/header.php` і синтаксичних помилок не виявлено.
- Переглянуто зміни через `git diff` і здійснено коміт з повідомленням `Осучаснено хедер із адаптивним макетом`, автоматичні перевірки пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b5da12f1083249306d28e89adcde6)