### PR TITLE
Оновлено дизайн хедера та мобільну адаптацію

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,30 +9,28 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <?php // Для головної сторінки залишаємо логотип без посилання, але зі спільною сучасною обгорткою. ?>
+                <div class="logo header_logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
-                <a href="/" class="logo">
+                <?php // На внутрішніх сторінках логотип лишається клікабельним та веде на головну. ?>
+                <a href="/" class="logo header_logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
                     <span class="sub_text_logo">
                         <?php echo Yii::t("main", 'кожен голос важливий'); ?>
                     </span>
                 </a>
             <?php endif; ?>
 
-            <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
-<?php /* * / ?>
-                <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
-<?php /* */ ?>
+            <?php // Права частина хедера: селектор мови + форма пошуку (без зміни функціональності). ?>
+            <div class="right_header_b header_controls">
+                <div class="header_language_wrap"><?= WLanguageSelector::widget(); ?></div>
                 <div class="search_b">
                     <form method="post" action="/site/search" name="HeaderSearch">
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -126,35 +126,47 @@ a:hover {
     max-width: 970px;
 }
 .header {
-    min-height: 100px;
+    min-height: 108px;
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
+    box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.12);
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    display: inline-flex;
+    flex-direction: column;
     text-decoration: none;
+}
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+.header_logo {
+    flex-shrink: 0;
 }
 .sub_text_logo {
     color: #fff;
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    margin-top: 2px;
+    line-height: 20px;
 }
 .right_header_b {
-    float: right;
     text-align: right;
-    margin-top: 13px;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
+    width: 170px;
+    height: 34px;
+    line-height: 30px;
     border: 1px solid #147536;
-    border-radius: 2px;
+    border-radius: 6px;
     background: #dce6e4;
-    margin-bottom: 10px;
+    margin-bottom: 8px;
+    padding: 0 8px;
 }
 .language_select:hover,
 .language_select:focus {
@@ -165,32 +177,63 @@ a.logo, div.logo {
 }
 .search_input {
     display: inline-block;
-    width: 300px;
-    height: 32px;
+    width: 340px;
+    height: 40px;
     border: 2px solid #147536;
     background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    border-radius: 8px;
+    padding: 0 42px 0 14px;
     color: #565656;
     outline: none;
+    transition: box-shadow .2s ease, border-color .2s ease, background .2s ease;
 }
 .search_input:hover,
 .search_input:focus {
     background: #fff;
     color: #000;
     border-color: #3ac469;
+    box-shadow: 0 0 0 3px rgba(58, 196, 105, 0.15);
 }
 .search_btn {
     position: absolute;
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 14px;
+    right: 14px;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+/* Адаптив хедера: зберігаємо ті самі візуальні елементи, але робимо блок зручним для мобільних. */
+@media (max-width: 767px) {
+    .header {
+        min-height: 0;
+    }
+    .header_row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+        padding-top: 12px;
+        padding-bottom: 12px;
+    }
+    .header_logo {
+        align-self: flex-start;
+    }
+    .right_header_b,
+    .header_controls {
+        width: 100%;
+        text-align: left;
+    }
+    .header_language_wrap {
+        margin-bottom: 8px;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+        max-width: 100%;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Хедер виглядав застарілим і потребував сучаснішого, більш гармонійного та мобільно-дружнього вигляду. 
- Зберегти поточну функціональність та візуальні елементи, включно з логотипом розміром `184x58`, підписом, селектором мови і формою пошуку. 

### Description
- Перебудовано HTML структуру хедера у `frontend/views/layouts/main/header.php`: додано обгортки `.header_row`, `.header_logo`, `.header_controls` та `.header_language_wrap` і додано коментарі українською без змін логіки оригінальних віджетів. 
- Оновлено стилі в `frontend/web/css/main.css`: перехід на flex-розкладку (`.header_row`), сучасніші відступи, радіуси, тіні, покращені стани фокусу для поля пошуку і збільшені елементи керування. 
- Додано адаптивні правила (`@media (max-width: 767px)`) щоб стекувати елементи в колонку на мобільних пристроях і робити селект/пошук на всю ширину. 
- Внесені мінімальні зміни до поведінки: CSRF-поле, submit через іконку і логіка перемикача мов залишились без змін; додано пояснювальні коментарі в коді. 

### Testing
- Запущено синтаксичну перевірку PHP: `php -l frontend/views/layouts/main/header.php` — перевірка пройшла без помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b5da12f1083249306d28e89adcde6)