### PR TITLE
Оновлено дизайн хедера та мобільну адаптивність

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -1,7 +1,6 @@
 <?php
 
 use frontend\widgets\WLanguageSelector;
-use frontend\widgets\WSearchForm;
 
 /** @var $this Controller */ ?>
 <!-- ~/frontend/views/layouts/main/header.php -->
@@ -9,37 +8,39 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
-            <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
-                    <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
-                </div>
-            <?php else: ?>
-                <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
-                    </span>
-                </a>
-            <?php endif; ?>
+        <?php // Головна обгортка хедера: адаптивний лейаут для десктопу і мобільних. ?>
+        <div class="row header_row">
+            <div class="header_brand_block">
+                <?php if (Yii::$app->request->url == '/') : ?>
+                    <div class="logo">
+                        <?php // Залишаємо ті самі розміри логотипа (184x58), як вимагалось. ?>
+                        <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                        <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
+                    </div>
+                <?php else: ?>
+                    <a href="/" class="logo">
+                        <?php // Залишаємо ті самі розміри логотипа (184x58), як вимагалось. ?>
+                        <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
+                        <br>
+                        <span class="sub_text_logo">
+                            <?php echo Yii::t("main", 'кожен голос важливий'); ?>
+                        </span>
+                    </a>
+                <?php endif; ?>
+            </div>
 
             <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
-<?php /* * / ?>
-                <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
-<?php /* */ ?>
-                <div class="search_b">
-                    <form method="post" action="/site/search" name="HeaderSearch">
-                        <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
-                        <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">
-                        <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
-                        <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
-                    </form>
+                <div class="header_controls">
+                    <?= WLanguageSelector::widget(); ?>
+
+                    <div class="search_b">
+                        <form method="post" action="/site/search" name="HeaderSearch">
+                            <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
+                            <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">
+                            <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
+                            <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -126,9 +126,20 @@ a:hover {
     max-width: 970px;
 }
 .header {
-    min-height: 100px;
+    min-height: 110px;
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.12);
+}
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    flex-wrap: wrap;
+}
+.header_brand_block {
+    flex: 0 0 auto;
 }
 a.logo, div.logo {
     margin-top: 10px;
@@ -140,39 +151,51 @@ a.logo, div.logo {
     display: inline-block;
     margin-left: 37px;
     line-height: 24px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.22);
 }
 .right_header_b {
-    float: right;
+    margin-left: auto;
     text-align: right;
     margin-top: 13px;
 }
+.header_controls {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+}
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
+    min-width: 165px;
+    height: 34px;
+    line-height: 30px;
+    padding: 0 10px;
     border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    border-radius: 6px;
+    background: rgba(240, 244, 244, 0.95);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    color: #055C2B;
 }
 .language_select:hover,
 .language_select:focus {
     background: #fff;
+    border-color: #3ac469;
 }
 .search_b {
     position: relative;
 }
 .search_input {
     display: inline-block;
-    width: 300px;
-    height: 32px;
+    width: 320px;
+    max-width: 100%;
+    height: 38px;
     border: 2px solid #147536;
     background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    border-radius: 8px;
+    padding: 0 40px 0 12px;
     color: #565656;
     outline: none;
+    box-shadow: 0 2px 7px rgba(0, 0, 0, 0.14);
 }
 .search_input:hover,
 .search_input:focus {
@@ -185,8 +208,8 @@ a.logo, div.logo {
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 13px;
+    right: 12px;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
@@ -3543,6 +3566,34 @@ a.pass_on_main_page {
     }
 }
 @media (max-width: 768px) {
+    /* Оновлений адаптив хедера: зручний стек для мобільних без втрати функціоналу. */
+    .header {
+        min-height: auto;
+        padding-bottom: 12px;
+    }
+    .header_row {
+        display: block;
+    }
+    a.logo, div.logo {
+        margin-top: 12px;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+        line-height: 22px;
+    }
+    .right_header_b {
+        margin-top: 8px;
+        margin-left: 0;
+        width: 100%;
+    }
+    .header_controls {
+        align-items: stretch;
+        width: 100%;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+    }
     .related-polls-title {
         font-size: 20px;
     }
@@ -3641,6 +3692,16 @@ a.pass_on_main_page {
     }
 }
 @media (max-width: 480px) {
+    .header {
+        padding-bottom: 10px;
+    }
+    .search_input {
+        height: 36px;
+        border-radius: 7px;
+    }
+    .search_btn {
+        top: 12px;
+    }
     .related-polls-item {
         gap: 10px;
         padding: 8px 10px;


### PR DESCRIPTION
### Motivation
- Хедер сайту виглядав застаріло й потребував сучасного, більш гармонічного вигляду з підтримкою мобільних пристроїв; при цьому потрібно було зберегти поточний функціонал і розміри логотипа.

### Description
- Перебудовано шаблон хедера у `frontend/views/layouts/main/header.php` і введено семантичні блоки `header_row`, `header_brand_block` та `header_controls` для кращого контролю лейауту.
- Збережено логотип у тих самих розмірах `184x58` для головної та внутрішніх сторінок і збережено форму пошуку з CSRF-полем та мовний селектор `WLanguageSelector`.
- Оновлено стилі в `frontend/web/css/main.css`: перехід на flex-лейаут, тіні, округлені поля, покращені відступи, більший та помітніший селект мови та модернізований інпут пошуку.
- Додано адаптивні правила для мобільних екранів (`@media (max-width: 768px)` та `@media (max-width: 480px)`), щоб селектор і пошук коректно займали ширину та хедер складався вертикально на малих екранах.

### Testing
- Запущена перевірка синтаксису PHP через `php -l frontend/views/layouts/main/header.php`, яка пройшла успішно.
- Перевірено відсутність проблем з відступами/конфігурацією через `git diff --check`, яка не виявила помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b5da12f1083249306d28e89adcde6)