### PR TITLE
Ребілд хедера: нова композиція і фікс overflow пошуку на мобільних

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -1,7 +1,6 @@
 <?php
 
 use frontend\widgets\WLanguageSelector;
-use frontend\widgets\WSearchForm;
 
 /** @var $this Controller */ ?>
 <!-- ~/frontend/views/layouts/main/header.php -->
@@ -9,37 +8,36 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
-            <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
-                    <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
-                </div>
-            <?php else: ?>
-                <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
-                    </span>
-                </a>
-            <?php endif; ?>
+        <div class="row header_row">
+            <div class="header_brand">
+                <?php if (Yii::$app->request->url == '/') : ?>
+                    <div class="logo" aria-label="Referendum.social">
+                        <?php // Зберігаємо незмінний розмір логотипа для візуальної цілісності бренду. ?>
+                        <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                        <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
+                    </div>
+                <?php else: ?>
+                    <a href="/" class="logo">
+                        <?php // Зберігаємо незмінний розмір логотипа для візуальної цілісності бренду. ?>
+                        <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                        <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
+                    </a>
+                <?php endif; ?>
+            </div>
 
-            <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
-<?php /* * / ?>
-                <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
-<?php /* */ ?>
+            <div class="header_controls">
                 <div class="search_b">
                     <form method="post" action="/site/search" name="HeaderSearch">
+                        <?php // Залишаємо CSRF-поле в формі, щоб пошук працював коректно. ?>
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
                         <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">
-                        <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
+                        <button type="submit" class="search_btn" aria-label="<?= Yii::t("main", 'Пошук'); ?>"></button>
                         <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
                     </form>
+                </div>
+
+                <div class="language_wrap">
+                    <?= WLanguageSelector::widget(); ?>
                 </div>
             </div>
         </div>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -130,8 +130,20 @@ a:hover {
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
 }
+/* Робимо відчутний ребілд: логотип зліва, керування справа у картці з чіткою ієрархією. */
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 28px;
+    padding: 14px 0;
+}
+.header_brand {
+    display: flex;
+    align-items: center;
+    min-width: 184px;
+}
 a.logo, div.logo {
-    margin-top: 10px;
     display: inline-block;
     text-decoration: none;
 }
@@ -140,57 +152,117 @@ a.logo, div.logo {
     display: inline-block;
     margin-left: 37px;
     line-height: 24px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
-.right_header_b {
-    float: right;
-    text-align: right;
-    margin-top: 13px;
+.header_controls {
+    width: min(100%, 510px);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px;
+    border-radius: 12px;
+    background: rgba(8, 102, 44, 0.26);
+    box-shadow: 0 6px 16px rgba(3, 44, 18, 0.2);
+}
+.language_wrap {
+    flex: 0 0 172px;
 }
 .language_select {
-    display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
-    border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    display: block;
+    width: 100%;
+    height: 38px;
+    line-height: 36px;
+    border: 1px solid #1a8542;
+    border-radius: 9px;
+    background: rgba(255, 255, 255, 0.92);
+    color: #055c2b;
+    font-weight: 600;
+    padding: 0 10px;
 }
 .language_select:hover,
 .language_select:focus {
     background: #fff;
+    border-color: #3ac469;
 }
 .search_b {
     position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.search_b form {
+    position: relative;
+    width: 100%;
 }
 .search_input {
-    display: inline-block;
-    width: 300px;
-    height: 32px;
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    height: 40px;
     border: 2px solid #147536;
-    background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    background: rgba(240, 244, 244, 0.96);
+    border-radius: 10px;
+    padding: 0 44px 0 14px;
     color: #565656;
     outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 .search_input:hover,
 .search_input:focus {
     background: #fff;
     color: #000;
     border-color: #3ac469;
+    box-shadow: 0 0 0 3px rgba(58, 196, 105, 0.2);
 }
 .search_btn {
     position: absolute;
+    border: 0;
+    padding: 0;
+    cursor: pointer;
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 50%;
+    right: 14px;
+    transform: translateY(-50%);
 }
 .search_input:hover ~ .search_btn,
-.search_input:focus ~ .search_btn {
+.search_input:focus ~ .search_btn,
+.search_btn:hover,
+.search_btn:focus {
     background: url(/img/layout/search_icon_hover.png);
+}
+
+/* Адаптуємо хедер під мобільні екрани без втрати функціональності. */
+@media (max-width: 767px) {
+    .header_row {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 12px;
+        padding: 12px 0;
+    }
+    .header_controls {
+        width: 100%;
+        flex-direction: column-reverse;
+        align-items: stretch;
+        gap: 10px;
+        padding: 10px;
+        box-sizing: border-box;
+    }
+    .language_wrap {
+        flex: 0 0 auto;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+        max-width: 100%;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+        margin-top: 4px;
+        line-height: 20px;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Поточний хедер виглядав занадто схожим на стару версію і потребував відчутного оновлення композиції та візуальної ієрархії.
- На мобільних пристроях поле пошуку іноді виходило за межі контейнера і створювало UX-проблему.
- Потрібно зберегти існуючий функціонал (логотип, слоган, пошук, перемикач мов) і розміри логотипа `184x58` при сучаснішому, компактному вигляді.

### Description
- Перебудовано розмітку хедера на два логічні блоки: `header_brand` (логотип + слоган) і `header_controls` (пошук + перемикач мов) для лаконічнішої композиції та кращої керованості стилями.
- Оновлено CSS: нова `header_row` з центровкою, `header_controls` як компактна картка з тінню, адаптивні правила у `@media (max-width: 767px)` і візуальні поліпшення елементів інтерфейсу.
- Виправлено overflow пошуку шляхом переведення `.search_input` на `width: 100%`, `box-sizing: border-box`, додавання `min-width: 0` до контейнера та забезпечення `form` шириною 100%.
- Технічні правки: замінено клікабельний `a`-тригер на семантичний `button type="submit"` у формі пошуку, видалено невикористаний імпорт `WSearchForm`, додано коментарі українською у коді.

### Testing
- `php -l frontend/views/layouts/main/header.php` — перевірка синтаксису пройшла без помилок.
- У цьому середовищі немає налаштованих автоматизованих UI/visual-regression тестів для перевірки рендеру; рекомендована додаткова візуальна перевірка у браузерах/емуляторах після деплою.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b619f16d88324b65025f32c181678)