### PR TITLE
Ребілд хедера: нова композиція, сучасні стилі та фікс переповнення пошуку на мобільних

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,35 +9,36 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
+                <div class="logo" aria-label="Referendum.social">
+                    <?php // Зберігаємо оригінальні пропорції логотипа 184x58 за вимогою. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
                 <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
-                    </span>
+                    <?php // Зберігаємо оригінальні пропорції логотипа 184x58 за вимогою. ?>
+                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                    <span class="sub_text_logo"><?php echo Yii::t("main", 'кожен голос важливий'); ?></span>
                 </a>
             <?php endif; ?>
 
-            <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
+            <div class="header_controls" aria-label="<?= Yii::t("main", 'Інструменти хедера'); ?>">
+                <div class="header_controls_top">
+                    <?= WLanguageSelector::widget(); ?>
+                </div>
 <?php /* * / ?>
-                <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
+                <div class="search_b" style="border:1px dashed red;">
+                    <?= WSearchForm::widget([]); ?>
+                </div>
 <?php /* */ ?>
                 <div class="search_b">
                     <form method="post" action="/site/search" name="HeaderSearch">
+                        <?php // Залишаємо CSRF-поле в формі, щоб пошук працював коректно. ?>
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
                         <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">
-                        <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
+                        <button type="submit" class="search_btn" aria-label="<?= Yii::t("main", 'Пошук'); ?>"></button>
                         <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
                     </form>
                 </div>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -130,8 +130,14 @@ a:hover {
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
 }
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 28px;
+    padding: 14px 0;
+}
 a.logo, div.logo {
-    margin-top: 10px;
     display: inline-block;
     text-decoration: none;
 }
@@ -140,57 +146,111 @@ a.logo, div.logo {
     display: inline-block;
     margin-left: 37px;
     line-height: 24px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
-.right_header_b {
-    float: right;
-    text-align: right;
-    margin-top: 13px;
+.header_controls {
+    width: min(420px, 100%);
+    display: grid;
+    gap: 12px;
+    padding: 12px;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(0, 80, 32, 0.22);
+    box-shadow: 0 10px 22px rgba(0, 43, 17, 0.25);
+    backdrop-filter: blur(2px);
+}
+.header_controls_top {
+    display: flex;
+    justify-content: flex-end;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
-    border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    width: 210px;
+    max-width: 100%;
+    height: 38px;
+    line-height: 36px;
+    border: 1px solid #1a8542;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.9);
+    color: #055c2b;
+    font-weight: 600;
+    padding: 0 10px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 .language_select:hover,
 .language_select:focus {
     background: #fff;
+    border-color: #3ac469;
 }
 .search_b {
     position: relative;
+    width: 100%;
 }
 .search_input {
-    display: inline-block;
-    width: 300px;
-    height: 32px;
+    display: block;
+    width: 100%;
+    height: 40px;
     border: 2px solid #147536;
-    background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    background: rgba(240, 244, 244, 0.96);
+    border-radius: 12px;
+    box-sizing: border-box;
+    padding: 0 44px 0 14px;
     color: #565656;
     outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 .search_input:hover,
 .search_input:focus {
     background: #fff;
     color: #000;
     border-color: #3ac469;
+    box-shadow: 0 0 0 3px rgba(58, 196, 105, 0.2);
 }
 .search_btn {
     position: absolute;
+    border: 0;
+    padding: 0;
+    cursor: pointer;
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 50%;
+    right: 14px;
+    transform: translateY(-50%);
 }
 .search_input:hover ~ .search_btn,
-.search_input:focus ~ .search_btn {
+.search_input:focus ~ .search_btn,
+.search_btn:hover,
+.search_btn:focus {
     background: url(/img/layout/search_icon_hover.png);
+}
+
+/* Адаптуємо хедер під мобільні екрани без втрати функціональності. */
+@media (max-width: 767px) {
+    .header_row {
+        align-items: stretch;
+        flex-direction: column;
+        gap: 14px;
+        padding: 12px 0;
+    }
+    .header_controls {
+        width: 100%;
+        padding: 10px;
+        gap: 10px;
+    }
+    .header_controls_top {
+        justify-content: stretch;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+        max-width: 100%;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+        margin-top: 4px;
+        line-height: 20px;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Хедер потрібно було реально перебудувати в більш лаконічну, сучасну композицію збереженням існуючого функціоналу і розміру логотипа 184×58.
- Виправити критичну проблему: поле пошуку виходило за межі екрану на мобільних пристроях.
- Підтримати дизайн у межах поточної зеленої стилістики сайту і забезпечити коректну мобільну адаптацію.

### Description
- Змінено розмітку хедера: замість попереднього правого стека додано панель `.header_controls` з підзоною `.header_controls_top` для перемикача мови та окремим блоком пошуку, що змінює візуальну композицію і робить її лаконічною (файл `frontend/views/layouts/main/header.php`).
- Оновлено стилі в `frontend/web/css/main.css`: панель керування оформлена як м’яка картка (`grid`, тіні, backdrop), підправлені відступи/розміри, оновлена типографіка елементів керування для сучасного вигляду.
- Виправлено overflow пошуку на мобільних: `search_b` та `.search_input` тепер повноширинні з `box-sizing: border-box`, інпут відображається як блок і більше не виштовхує layout за межі viewport; також підправлено положення кнопки пошуку.
- Збережено функціонал форми (CSRF-поле, параметри пошуку) і розмір логотипа 184×58 у обох гілках рендеру; додано/оновлено українські коментарі у коді за правилом «коментарі в коді українською».

### Testing
- `php -l frontend/views/layouts/main/header.php` — синтаксичних помилок не виявлено (успішно).
- Локально перевірено зміни через `git diff` для `frontend/views/layouts/main/header.php` та `frontend/web/css/main.css` і підтверджено очікувані правки (успішно).
- Перевірено, що на мобільних стилях (`@media (max-width: 767px)`) поле пошуку і панель керування використовують `width: 100%` і `box-sizing: border-box`, що усуває переповнення (успішно).
- UI-рендерів/скріншотів у цьому CLI-середовищі автоматично не згенеровано через відсутність браузерного рендеру; рекомендовано швидку візуальну перевірку на реальних пристроях/емуляторах (320px, 375px, 768px, desktop).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b619f16d88324b65025f32c181678)