### PR TITLE
Оновити дизайн хедера для сучасного та мобільного вигляду

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -3,33 +3,33 @@
 use frontend\widgets\WLanguageSelector;
 use frontend\widgets\WSearchForm;
 
-/** @var $this Controller */ ?>
+/** @var $this Controller */
+$isHomePage = Yii::$app->request->url == '/';
+?>
 <!-- ~/frontend/views/layouts/main/header.php -->
 <!-- Header
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
-            <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+        <div class="row header_row">
+            <?php if ($isHomePage) : ?>
+                <?php // На головній лишаємо логотип без посилання, щоби не дублювати переходи на поточну сторінку. ?>
+                <div class="logo" aria-label="referendum.social">
+                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
-                <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
+                <?php // На внутрішніх сторінках зберігаємо перехід на головну через логотип. ?>
+                <a href="/" class="logo" aria-label="referendum.social">
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
-                    </span>
+                    <span class="sub_text_logo"><?php echo Yii::t("main", 'кожен голос важливий'); ?></span>
                 </a>
             <?php endif; ?>
 
             <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
+                <div class="header_top_tools">
+                    <?= WLanguageSelector::widget(); ?>
+                </div>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>
@@ -37,6 +37,7 @@ use frontend\widgets\WSearchForm;
                     <form method="post" action="/site/search" name="HeaderSearch">
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
                         <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">
+                        <?php // Кнопку залишаємо посиланням для сумісності зі старим JS-кліком. ?>
                         <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
                         <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
                     </form>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -129,11 +129,29 @@ a:hover {
     min-height: 100px;
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
+    box-shadow: 0 6px 24px rgba(6, 57, 29, 0.2);
+}
+/* Формуємо сучасну композицію шапки з адаптивним перенесенням блоків. */
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 12px 0;
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    margin-top: 0;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
     text-decoration: none;
+    padding: 8px 12px;
+    border-radius: 10px;
+    transition: background-color 0.2s ease;
+}
+a.logo:hover,
+a.logo:focus {
+    background-color: rgba(255, 255, 255, 0.08);
 }
 .sub_text_logo {
     color: #fff;
@@ -142,9 +160,16 @@ a.logo, div.logo {
     line-height: 24px;
 }
 .right_header_b {
-    float: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
     text-align: right;
-    margin-top: 13px;
+    gap: 10px;
+}
+.header_top_tools {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
 }
 .language_select {
     display: inline-block;
@@ -192,6 +217,50 @@ a.logo, div.logo {
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
 }
+
+@media (max-width: 767px) {
+    /* На мобільних центруємо блоки, щоб шапка виглядала охайно на вузьких екранах. */
+    .header_row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+        padding: 10px 0 14px;
+    }
+
+    a.logo,
+    div.logo {
+        align-items: center;
+        width: 100%;
+        padding: 6px 0;
+    }
+
+    .sub_text_logo {
+        margin-left: 0;
+        text-align: center;
+        line-height: 20px;
+    }
+
+    .right_header_b {
+        align-items: center;
+        text-align: center;
+        width: 100%;
+    }
+
+    .header_top_tools {
+        justify-content: center;
+    }
+
+    .search_b,
+    .search_b form {
+        width: 100%;
+    }
+
+    .search_input {
+        width: 100%;
+        max-width: 100%;
+    }
+}
+
 .sub_header_slider_b {
     height: 81px;
     border-bottom: 1px solid #b7c8ca;


### PR DESCRIPTION
### Motivation
- Хедер виглядав застарілим і потребував сучаснішої композиції та кращої адаптивності для мобільних пристроїв.
- Потрібно зберегти існуючий функціонал (логотип, перемикач мов, пошук, логіку відправлення форми) і розміри логотипа (`184x58`).
- Зміни мають органічно вписуватися в поточну стилістику сайту і не впливати на бекенд-логіку.

### Description
- Перероблено шаблон `frontend/views/layouts/main/header.php`: додано змінну `$isHomePage`, пояснювальні коментарі та `aria-label` для логотипа, збережено поточну поведінку логотипа на головній і внутрішніх сторінках. 
- Оновлено CSS в `frontend/web/css/main.css`: перехід на flex-композицію через `.header_row`, додано м’яку тінь, hover-стан для логотипа та сучасні відступи/заповнення.
- Додано компонентний контейнер `.header_top_tools` для інструментів (перемикач мов) і зберегли пошукову форму без змін логіки (кнопка-посилання для сумісності зі старим JS).
- Реалізовано адаптивні правила у медіа-запиті `@media (max-width: 767px)` для вертикального компонування, центрування елементів і розтягнення поля пошуку на всю ширину на мобільних.

### Testing
- `php -l frontend/views/layouts/main/header.php` — синтаксична перевірка пройшла успішно.
- Автоматизованих unit/integration тестів для цих файлів не виконувалось; змінено лише представлення та CSS без втручання в бекенд-логіку.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b6918295c8324b2b60677dfc4748b)