### PR TITLE
Оновити вигляд хедера та мобільну адаптацію

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,27 +9,25 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
-            <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
-                    <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
-                </div>
-            <?php else: ?>
-                <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
-                    </span>
-                </a>
-            <?php endif; ?>
+        <div class="row header_row">
+            <div class="header_brand_block">
+                <?php if (Yii::$app->request->url == '/') : ?>
+                    <div class="logo" aria-label="Referendum home brand block">
+                        <?php // Зберігаємо той самий розмір логотипа (184x58), щоб не ламати композицію сторінок. ?>
+                        <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
+                        <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
+                    </div>
+                <?php else: ?>
+                    <a href="/" class="logo" aria-label="<?= Yii::t("main", 'На головну'); ?>">
+                        <?php // Зберігаємо той самий розмір логотипа (184x58), щоб не ламати композицію сторінок. ?>
+                        <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
+                        <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
+                    </a>
+                <?php endif; ?>
+            </div>
 
             <div class="right_header_b">
                 <?= WLanguageSelector::widget(); ?>
-                <br>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>
@@ -37,6 +35,7 @@ use frontend\widgets\WSearchForm;
                     <form method="post" action="/site/search" name="HeaderSearch">
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
                         <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">
+                        <?php // Лишаємо submit через клік на іконку, щоб зберегти поточну поведінку інтерфейсу. ?>
                         <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
                         <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
                     </form>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -126,25 +126,41 @@ a:hover {
     max-width: 970px;
 }
 .header {
+    /* Осучаснений верхній блок: м’який градієнт + легка тінь без зміни палітри бренду. */
     min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
-    border-bottom: 2px solid #147536;
+    background: linear-gradient(135deg, #0f6b33 0%, #147536 55%, #1a8f45 100%);
+    border-bottom: 1px solid #0d5829;
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.16);
+}
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px 0;
+}
+.header_brand_block {
+    display: flex;
+    align-items: center;
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
     text-decoration: none;
 }
 .sub_text_logo {
-    color: #fff;
+    color: #eaf8ef;
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    line-height: 20px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 .right_header_b {
-    float: right;
-    text-align: right;
-    margin-top: 13px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
 }
 .language_select {
     display: inline-block;
@@ -191,6 +207,46 @@ a.logo, div.logo {
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+
+
+/* Мобільна адаптація: всі ключові елементи хедера збережені, але перебудовані у вертикальний стек. */
+@media (max-width: 767px) {
+    .header {
+        min-height: 0;
+    }
+    .header_row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+        padding: 10px 0 12px;
+    }
+    .header_brand_block {
+        justify-content: center;
+    }
+    a.logo, div.logo {
+        align-items: center;
+        width: 100%;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+        margin-top: 2px;
+        text-align: center;
+    }
+    .right_header_b {
+        align-items: stretch;
+        width: 100%;
+    }
+    .language_select {
+        width: 100%;
+        max-width: 100%;
+    }
+    .search_input {
+        width: 100%;
+    }
+    .search_btn {
+        right: 12px;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Поточний блок хедера виглядає застарілим і потребує сучаснішого візуального оформлення при збереженні існуючого функціоналу та розмірів логотипа.
- Потрібно забезпечити, щоб хедер гармоніював із загальною палітрою сайту і коректно відображався на мобільних пристроях.

### Description
- Перероблено шаблон `frontend/views/layouts/main/header.php`: додано обгортки `.header_row` та `.header_brand_block`, залишено логіку відображення логотипа з розмірами `184x58`, додано коментарі та `aria-label` для доступності.
- Оновлено стилі в `frontend/web/css/main.css`: заміна фону на градієнт, тонша нижня межа, додана тінь та відступи; перехід від плаваючого верстування до `flex`-контейнерів для кращого вирівнювання.
- Додано мобільну адаптацію через `@media (max-width: 767px)`, яка перестроює хедер у вертикальний стек, робить селектор мови та поле пошуку на всю ширину і коригує відступи для читабельності.
- Збережено поточну поведінку пошуку (відправка форми по кліку на іконку) та віджет вибору мови без змін у функціоналі.

### Testing
- `php -l frontend/views/layouts/main/header.php` — перевірка синтаксису PHP успішна (без помилок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b6918295c8324b2b60677dfc4748b)