### PR TITLE
Оновлено хедер: сучасніший вигляд, збережено функціонал

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -1,7 +1,6 @@
 <?php
 
 use frontend\widgets\WLanguageSelector;
-use frontend\widgets\WSearchForm;
 
 /** @var $this Controller */ ?>
 <!-- ~/frontend/views/layouts/main/header.php -->
@@ -9,30 +8,28 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                <?php // Залишаємо не-клікабельний логотип на головній сторінці для коректної семантики. ?>
+                <div class="logo">
+                    <?php // Зберігаємо розміри логотипа без змін, як вимагалось у задачі. ?>
+                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
+                <?php // На внутрішніх сторінках логотип залишається посиланням на головну. ?>
                 <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
+                    <?php // Зберігаємо розміри логотипа без змін, як вимагалось у задачі. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
                     <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
+                        <?= Yii::t("main", 'кожен голос важливий'); ?>
                     </span>
                 </a>
             <?php endif; ?>
 
             <div class="right_header_b">
                 <?= WLanguageSelector::widget(); ?>
-                <br>
-<?php /* * / ?>
-                <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
-<?php /* */ ?>
+
                 <div class="search_b">
                     <form method="post" action="/site/search" name="HeaderSearch">
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -125,52 +125,69 @@ a:hover {
 .container {
     max-width: 970px;
 }
+/* Оновлений хедер: сучасніші відступи/контрасти без зміни ключового функціоналу. */
 .header {
-    min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
+    min-height: 110px;
+    background: linear-gradient(180deg, rgba(16, 96, 47, 0.95) 0%, rgba(13, 80, 39, 0.95) 100%), url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
+    box-shadow: 0 4px 18px rgba(4, 44, 21, 0.25);
+}
+/* Використовуємо flex-розкладку, щоб блок виглядав сучасно і стабільно на різних ширинах. */
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 14px 0;
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
     text-decoration: none;
 }
 .sub_text_logo {
-    color: #fff;
+    color: rgba(255, 255, 255, 0.92);
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    margin-top: 2px;
+    line-height: 22px;
+    letter-spacing: 0.2px;
 }
 .right_header_b {
-    float: right;
-    text-align: right;
-    margin-top: 13px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
+    width: 132px;
+    height: 32px;
     line-height: 22px;
-    border: 1px solid #147536;
-    border-radius: 2px;
+    border: 1px solid #1b8b45;
+    border-radius: 8px;
     background: #dce6e4;
-    margin-bottom: 10px;
+    margin-bottom: 0;
+    padding: 4px 10px;
+    color: #0d4d25;
 }
 .language_select:hover,
 .language_select:focus {
     background: #fff;
+    box-shadow: 0 0 0 3px rgba(58, 196, 105, 0.25);
 }
 .search_b {
     position: relative;
 }
 .search_input {
     display: inline-block;
-    width: 300px;
-    height: 32px;
+    width: 320px;
+    height: 38px;
     border: 2px solid #147536;
     background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    border-radius: 10px;
+    padding: 0 38px 0 12px;
     color: #565656;
     outline: none;
 }
@@ -179,18 +196,41 @@ a.logo, div.logo {
     background: #fff;
     color: #000;
     border-color: #3ac469;
+    box-shadow: 0 0 0 3px rgba(58, 196, 105, 0.25);
 }
 .search_btn {
     position: absolute;
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 12px;
+    right: 12px;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+/* Адаптуємо хедер для вузьких екранів, не змінюючи логіку елементів. */
+@media (max-width: 767px) {
+    .header_row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .right_header_b {
+        width: 100%;
+        align-items: stretch;
+    }
+
+    .language_select,
+    .search_input {
+        width: 100%;
+    }
+
+    .sub_text_logo {
+        margin-left: 0;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Хедер сайту виглядав застаріло і потребував візуального оновлення для сучаснішого та більш гармонічного вигляду без втрати існуючого функціоналу.
- Потрібно зберегти всі наявні елементи та розміри логотипа (`184x58`), при цьому прибрати інлайн-стилі й зробити розмітку більш адаптивною і стійкою.

### Description
- Перебудовано HTML у `frontend/views/layouts/main/header.php`: додано контейнер `header_row`, прибрано інлайн-стилі й зайвий `use frontend\widgets\WSearchForm;`, збережено семантику (на головній — `div.logo`, на внутрішніх — `a.logo`) і додано пояснювальні коментарі українською.
- Оновлено стилі в `frontend/web/css/main.css`: перехід на `flex` для `header_row`, сучасний градієнт і тінь, покращені відступи, оновлені `language_select` і `search_input` (нові розміри, border-radius, фокуси/hover), а також адаптивні правила `@media` для вузьких екранів.
- Збережено весь існуючий функціонал: перемикач мови, форма пошуку із CSRF-полем, логотип із тими самими розмірами і текстовим слоганом.

### Testing
- `php -l frontend/views/layouts/main/header.php` — пройшов без синтаксичних помилок (успішно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b6ad6d97c8324abeb1039926efdb9)