### PR TITLE
Оновлено сучасний вигляд хедера без зміни функціоналу

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,9 +9,9 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo" aria-label="Referendum social logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
@@ -29,7 +29,7 @@ use frontend\widgets\WSearchForm;
 
             <div class="right_header_b">
                 <?= WLanguageSelector::widget(); ?>
-                <br>
+                <?php // Прибираємо застарілий перенос рядка й керуємо відступами тільки через CSS. ?>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -130,10 +130,19 @@ a:hover {
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
 }
+/* Оновлений контейнер хедера: зберігаємо контент і додаємо сучасну адаптивну композицію. */
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 0 12px;
+}
 a.logo, div.logo {
-    margin-top: 10px;
     display: inline-block;
     text-decoration: none;
+    margin-top: 0;
+    flex-shrink: 0;
 }
 .sub_text_logo {
     color: #fff;
@@ -142,23 +151,36 @@ a.logo, div.logo {
     line-height: 24px;
 }
 .right_header_b {
-    float: right;
+    float: none;
     text-align: right;
-    margin-top: 13px;
+    margin-top: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+    background: rgba(255, 255, 255, 0.09);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 12px;
+    padding: 10px 12px;
+    backdrop-filter: blur(3px);
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
+    width: 160px;
+    height: 32px;
+    line-height: 30px;
     border: 1px solid #147536;
-    border-radius: 2px;
+    border-radius: 8px;
     background: #dce6e4;
-    margin-bottom: 10px;
+    margin-bottom: 0;
+    padding: 0 10px;
+    color: #055c2b;
 }
 .language_select:hover,
 .language_select:focus {
     background: #fff;
+    border-color: #3ac469;
+    outline: none;
 }
 .search_b {
     position: relative;
@@ -169,8 +191,9 @@ a.logo, div.logo {
     height: 32px;
     border: 2px solid #147536;
     background: #f0f4f4;
-    border-radius: 4px;
+    border-radius: 8px;
     padding-left: 12px;
+    padding-right: 36px;
     color: #565656;
     outline: none;
 }
@@ -191,6 +214,22 @@ a.logo, div.logo {
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+@media (max-width: 767px) {
+    /* Робимо хедер мобільним без втрати функціоналу та поточних елементів. */
+    .header_row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+    .right_header_b {
+        width: 100%;
+        align-items: stretch;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Хедер сайту візуально застарів і потребував сучасного, адаптивного компонування без зміни наявного функціоналу та розмірів логотипа `184x58`.
- Потрібно зберегти ті самі елементи (селектор мови, поле пошуку з CSRF та сабмітом, підпис логотипа) і зробити їх візуально гармонічними з поточним стилем сайту.
- Також важливо уникнути інлайнових стилів у шаблоні й перемістити керування відступами/композицією в CSS для кращої підтримуваності.

### Description
- У шаблоні `frontend/views/layouts/main/header.php` додано структурний клас `header_row`, прибрано інлайнові стилі у блоці логотипа та додано `aria-label` для логотипа; збережено розмір логотипа `184x58` і поточну логіку форми пошуку. 
- У `frontend/web/css/main.css` додано правила для `.header_row` з Flexbox-композицією для сучасного компонування та відступів. 
- Оновлено стиль правого блоку (`.right_header_b`) з візуальною картою (скруглення, напівпрозора панель, padding) та покращено стилі для `language_select` і `search_input` (скруглення, фокус/hover стани, відступи). 
- Додано адаптивні медіа-правила (`@media (max-width: 767px)`) щоб блоки хедера коректно перебудовувались у колонку на мобільних пристроях, а також додано коментарі в коді українською.

### Testing
- Виконано синтаксичну перевірку PHP файла за командою `php -l frontend/views/layouts/main/header.php` — помилок синтаксису не виявлено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b6ad6d97c8324abeb1039926efdb9)