### PR TITLE
Оновлено дизайн хедера — сучасний вигляд з збереженим функціоналом

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,15 +9,15 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo header_logo_wrap">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
-                <a href="/" class="logo">
+                <a href="/" class="logo header_logo_wrap">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <br>
@@ -28,8 +28,11 @@ use frontend\widgets\WSearchForm;
             <?php endif; ?>
 
             <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
+                <?php // Групуємо елементи хедера у сучасний гнучкий контейнер без зміни функціоналу. ?>
+                <div class="header_tools">
+                    <div class="header_language">
+                        <?= WLanguageSelector::widget(); ?>
+                    </div>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>
@@ -40,7 +43,9 @@ use frontend\widgets\WSearchForm;
                         <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
                         <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
                     </form>
-                </div>
+                                </div>
+                <?php // Пошук залишаємо з тією ж POST-формою та CSRF-захистом. ?>
+            </div>
             </div>
         </div>
     </div>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -125,36 +125,57 @@ a:hover {
 .container {
     max-width: 970px;
 }
+/* Оновлений хедер: сучасніший вигляд при збереженні поточної айдентики. */
 .header {
-    min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
-    border-bottom: 2px solid #147536;
+    min-height: 108px;
+    background: linear-gradient(180deg, #0f5d2a 0%, #147536 100%);
+    border-bottom: 2px solid #0f5d2a;
+    box-shadow: 0 8px 20px rgba(8, 56, 25, 0.25);
+}
+.header_row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
+    padding: 14px 0 12px;
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    display: inline-flex;
+    flex-direction: column;
     text-decoration: none;
 }
+.header_logo_wrap img {
+    width: 184px;
+    height: 58px;
+}
 .sub_text_logo {
-    color: #fff;
+    color: #eaf6ef;
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    margin-top: 4px;
+    line-height: 20px;
 }
 .right_header_b {
-    float: right;
-    text-align: right;
-    margin-top: 13px;
+    margin-left: auto;
+}
+/* Інструменти хедера вирівнюємо колонкою для чистішої композиції. */
+.header_tools {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
-    border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    width: 140px;
+    height: 32px;
+    line-height: 30px;
+    border: 1px solid #0b5425;
+    border-radius: 8px;
+    background: #e6efe9;
+    padding: 0 8px;
+    box-shadow: 0 2px 8px rgba(7, 43, 20, 0.2);
 }
 .language_select:hover,
 .language_select:focus {
@@ -165,14 +186,15 @@ a.logo, div.logo {
 }
 .search_input {
     display: inline-block;
-    width: 300px;
-    height: 32px;
-    border: 2px solid #147536;
-    background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
-    color: #565656;
+    width: 320px;
+    height: 36px;
+    border: 1px solid #0f5d2a;
+    background: #f7fbf8;
+    border-radius: 10px;
+    padding-left: 14px;
+    color: #1f3f2a;
     outline: none;
+    box-shadow: 0 2px 8px rgba(7, 43, 20, 0.15);
 }
 .search_input:hover,
 .search_input:focus {
@@ -185,8 +207,8 @@ a.logo, div.logo {
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 12px;
+    right: 12px;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {


### PR DESCRIPTION
### Motivation
- Хедер був візуально застарілий і потребував оновлення для сучаснішої, гармонічної подачі без втрати існуючого функціоналу.
- Потрібно зберегти поточні елементи (перемикання мови, пошук, підпис під логотипом) і розміри логотипу (184x58).

### Description
- Перероблено розмітку хедера в `frontend/views/layouts/main/header.php`: додано `header_row`, обгортку `header_logo_wrap` для логотипа та `header_tools` для мовного селектора і пошуку, причому додані коментарі в коді для пояснення рішень.
- Оновлено стилі в `frontend/web/css/main.css`: перехід на `flex`-композицію (`.header_row`), сучасний градієнт і тінь для `.header`, поліпшені стилі для `.language_select` та `.search_input` (розміри, радіуси, тіні), збережено логіку і кольорову гаму сайту.
- Видалені зайві інлайн-стилі в розмітці логотипа і забезпечено збереження розмірів зображення через CSS (`width: 184px; height: 58px;`).
- Додано пояснювальні коментарі у файлах змін для подальшого супроводу і відповідно до принципу «не нашкодь». 

### Testing
- `php -l frontend/views/layouts/main/header.php` — синтаксичних помилок не виявлено (успішно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b6ad6d97c8324abeb1039926efdb9)