### PR TITLE
Осучаснено хедер: flex-структура та оновлені стилі

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,9 +9,10 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <?php // Новий обгортковий блок для сучасного, адаптивного вирівнювання елементів хедера. ?>
+        <div class="row header_inner">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
@@ -27,12 +28,15 @@ use frontend\widgets\WSearchForm;
                 </a>
             <?php endif; ?>
 
-            <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
+            <div class="right_header_b" aria-label="Header controls">
+                <?php // Зберігаємо існуючий віджет мов, але розміщуємо його в окремому рядку керування. ?>
+                <div class="header_control_row">
+                    <?= WLanguageSelector::widget(); ?>
+                </div>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>
+                <?php // Пошук залишився функціонально ідентичним, змінили лише візуальне оформлення контейнера. ?>
                 <div class="search_b">
                     <form method="post" action="/site/search" name="HeaderSearch">
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -125,36 +125,56 @@ a:hover {
 .container {
     max-width: 970px;
 }
+/* Осучаснений хедер: зберігаємо фірмові кольори та структуру, додаємо більше "повітря" й адаптивності. */
 .header {
-    min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
+    min-height: 112px;
+    background: linear-gradient(180deg, rgba(7, 108, 51, 0.94) 0%, rgba(6, 95, 45, 0.97) 100%), url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
+    box-shadow: 0 8px 24px rgba(3, 46, 22, 0.22);
+}
+.header_inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 14px 0;
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    margin-top: 0;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
     text-decoration: none;
 }
 .sub_text_logo {
-    color: #fff;
+    color: #e8fff0;
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    line-height: 22px;
+    letter-spacing: 0.2px;
 }
 .right_header_b {
-    float: right;
     text-align: right;
-    margin-top: 13px;
+    margin-top: 0;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    backdrop-filter: blur(1px);
+}
+.header_control_row {
+    margin-bottom: 10px;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
+    width: 142px;
+    height: 30px;
+    line-height: 28px;
     border: 1px solid #147536;
-    border-radius: 2px;
+    border-radius: 6px;
     background: #dce6e4;
-    margin-bottom: 10px;
+    margin-bottom: 0;
+    padding: 0 6px;
 }
 .language_select:hover,
 .language_select:focus {
@@ -165,12 +185,14 @@ a.logo, div.logo {
 }
 .search_input {
     display: inline-block;
-    width: 300px;
-    height: 32px;
+    width: 320px;
+    max-width: 100%;
+    height: 36px;
     border: 2px solid #147536;
     background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    border-radius: 18px;
+    padding-left: 14px;
+    padding-right: 34px;
     color: #565656;
     outline: none;
 }
@@ -185,12 +207,26 @@ a.logo, div.logo {
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 12px;
+    right: 12px;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+@media (max-width: 991px) {
+    .header_inner {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+    .right_header_b {
+        width: 100%;
+        text-align: left;
+    }
+    .search_input {
+        width: 100%;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Хедер виглядав застаріло і потребував сучасного, адаптивного вирівнювання при збереженні існуючого функціоналу та розмірів логотипа.

### Description
- Додано контейнер `header_inner` і переведено верстку хедера на флекс-вирівнювання для кращої адаптивності та простішого контролю розміщення елементів у рядку.
- Видалено зайвий інлайн-стиль у блоку логотипа і збережено розміри логотипа `184x58` щоб візуально не змінювати фірмовий знак.
- Оновлено CSS у `frontend/web/css/main.css`: градієнтний фон, тінь, оформлення правого блоку керування, більші/округлені елементи форми пошуку і покращений селект мови; додано медіа-правила для мобільних розмірів.
- Додано зрозумілі коментарі в коді українською для пояснення змін і збереження принципу «не нашкодь».\n
### Testing
- Виконано перевірку синтаксису PHP через `php -l frontend/views/layouts/main/header.php` і результат — синтаксис валідний.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b6ad6d97c8324abeb1039926efdb9)