### PR TITLE
Редизайн хедера: впровадження `header_row` та адаптивних стилів

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,19 +9,18 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
                 <a href="/" class="logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
+                        <span class="sub_text_logo">
                         <?php echo Yii::t("main", 'кожен голос важливий'); ?>
                     </span>
                 </a>
@@ -29,7 +28,6 @@ use frontend\widgets\WSearchForm;
 
             <div class="right_header_b">
                 <?= WLanguageSelector::widget(); ?>
-                <br>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -130,8 +130,18 @@ a:hover {
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
 }
+
+.header_row {
+    /* Оновлений хедер: гнучке компонування з вирівнюванням елементів керування. */
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 16px;
+    min-height: 96px;
+}
 a.logo, div.logo {
-    margin-top: 10px;
+    margin-top: 0;
     display: inline-block;
     text-decoration: none;
 }
@@ -142,9 +152,12 @@ a.logo, div.logo {
     line-height: 24px;
 }
 .right_header_b {
-    float: right;
-    text-align: right;
-    margin-top: 13px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 0;
+    margin-left: auto;
 }
 .language_select {
     display: inline-block;
@@ -162,6 +175,7 @@ a.logo, div.logo {
 }
 .search_b {
     position: relative;
+    display: inline-block;
 }
 .search_input {
     display: inline-block;
@@ -191,6 +205,24 @@ a.logo, div.logo {
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+
+@media (max-width: 767px) {
+    .header_row {
+        align-items: flex-start;
+        gap: 10px;
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+
+    .right_header_b {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .search_input {
+        width: 220px;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Сучасне та адаптивне компонування хедера зберігаючи існуючі елементи керування та візуальний стиль сайту.
- Забезпечити гнучке вирівнювання логотипа, селектора мови/піддомену і форми пошуку без зміни розміру логотипа (184x58).

### Description
- Оновлено шаблон `frontend/views/layouts/main/header.php`: замінено контейнер `.row` на `<div class="row header_row">`, видалено інлайнові стилі логотипа та зайві `<br>`, збережено розмір логотипа `width="184" height="58"` та існуючі контролери (пошук, селектор мови).
- Оновлено `frontend/web/css/main.css`: додано стилі `.header_row` (flex-розкладка), змінено `.right_header_b` на flex-вирівнювання, встановлено `.search_b` як `inline-block` і додано адаптивні правила в `@media (max-width: 767px)` для мобільних екранів.
- Додано коментарі в коді (PHP/CSS) про призначення змін для покращення підтримуваності.

### Testing
- Виконано `php -l frontend/views/layouts/main/header.php` — синтаксичних помилок не виявлено (успішно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b7022be748324be5b97ffc9f6eaf7)