### PR TITLE
Редизайн header_row із збереженням контролів

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,7 +9,8 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <?php // Редизайн хедера: зберігаємо ті самі елементи керування, але оновлюємо структуру для сучасної сітки. ?>
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
                 <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
@@ -29,7 +30,7 @@ use frontend\widgets\WSearchForm;
 
             <div class="right_header_b">
                 <?= WLanguageSelector::widget(); ?>
-                <br>
+                <?php // Замість переносу рядка використовуємо вертикальний flex-контейнер у CSS. ?>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -130,10 +130,18 @@ a:hover {
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
 }
+/* Оновлена побудова хедера: зберігаємо фірмовий стиль і наявні контроли, але робимо адаптивний ряд. */
+.header_row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+}
 a.logo, div.logo {
     margin-top: 10px;
     display: inline-block;
     text-decoration: none;
+    flex-shrink: 0;
 }
 .sub_text_logo {
     color: #fff;
@@ -142,7 +150,9 @@ a.logo, div.logo {
     line-height: 24px;
 }
 .right_header_b {
-    float: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
     text-align: right;
     margin-top: 13px;
 }
@@ -191,6 +201,23 @@ a.logo, div.logo {
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+@media (max-width: 767px) {
+    /* На мобільних переносимо блоки в колонку без втрати керування пошуком і вибором мови/піддомену. */
+    .header_row {
+        flex-direction: column;
+        gap: 12px;
+    }
+    .right_header_b {
+        width: 100%;
+        align-items: flex-start;
+        text-align: left;
+        margin-top: 0;
+    }
+    .search_input {
+        width: 100%;
+        max-width: 300px;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Перетворити верстку хедера на сучасну, адаптивну структуру, зберігаючи існуючі елементи керування.
- Забезпечити відповідність загальному стилю сайту без зміни розміру логотипа.
- Зробити мобільну адаптацію для коректного відображення пошуку та селектора мови/піддомену.

### Description
- Додано клас `header_row` у `frontend/views/layouts/main/header.php` та українські коментарі, при цьому збережено віджет `WLanguageSelector` і форму пошуку `HeaderSearch`.
- Оновлено `frontend/web/css/main.css`: додано правила для `.header_row` з `display: flex`, налаштовано вертикальне компонування для `.right_header_b` та додано `@media (max-width: 767px)` для мобільної адаптації.
- Збережено розмір логотипа `width="184" height="58"` у розмітці, без змін бізнес-логіки відображення.
- Додано пояснювальні коментарі в коді українською відповідно до вимоги документувати зміни.

### Testing
- Виконано синтаксичну перевірку `php -l frontend/views/layouts/main/header.php` — перевірка пройшла успішно (немає синтаксичних помилок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b7022be748324be5b97ffc9f6eaf7)