### PR TITLE
Оновлено дизайн хедера для сучасного вигляду та мобільних

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,15 +9,17 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <?php // Головна сторінка: залишаємо div для семантичної відповідності поточній логіці. ?>
+                <div class="logo header_logo_wrap" style="margin-top: 10px; display: inline-block; text-decoration: none;">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
-                <a href="/" class="logo">
+                <?php // Внутрішні сторінки: залишаємо посилання на головну без зміни функціоналу. ?>
+                <a href="/" class="logo header_logo_wrap">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <br>
@@ -27,7 +29,7 @@ use frontend\widgets\WSearchForm;
                 </a>
             <?php endif; ?>
 
-            <div class="right_header_b">
+            <div class="right_header_b header_controls_wrap">
                 <?= WLanguageSelector::widget(); ?>
                 <br>
 <?php /* * / ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -126,25 +126,49 @@ a:hover {
     max-width: 970px;
 }
 .header {
-    min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
-    border-bottom: 2px solid #147536;
+    min-height: 108px;
+    background: linear-gradient(180deg, #1c8e45 0%, #147536 100%);
+    border-bottom: 2px solid #0f5f2b;
+    box-shadow: 0 10px 24px rgba(10, 76, 35, 0.22);
+}
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
 }
 a.logo, div.logo {
     margin-top: 10px;
     display: inline-block;
     text-decoration: none;
 }
+.header_logo_wrap {
+    margin-top: 0 !important;
+    padding: 16px 0 14px;
+}
+.header_logo_wrap img {
+    display: block;
+    width: 184px;
+    height: 58px;
+}
 .sub_text_logo {
-    color: #fff;
+    color: #e6f8ee;
     display: inline-block;
-    margin-left: 37px;
-    line-height: 24px;
+    margin-left: 38px;
+    margin-top: 2px;
+    line-height: 20px;
+    font-size: 13px;
+    letter-spacing: .02em;
 }
 .right_header_b {
     float: right;
     text-align: right;
     margin-top: 13px;
+}
+.header_controls_wrap {
+    margin-top: 0;
+    padding: 16px 0;
 }
 .language_select {
     display: inline-block;
@@ -173,6 +197,8 @@ a.logo, div.logo {
     padding-left: 12px;
     color: #565656;
     outline: none;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.10);
+    transition: border-color .2s ease, box-shadow .2s ease, background-color .2s ease;
 }
 .search_input:hover,
 .search_input:focus {
@@ -187,6 +213,49 @@ a.logo, div.logo {
     background: url(/img/layout/search_icon.png);
     top: 10px;
     right: 10px;
+}
+
+/* Адаптуємо хедер для планшетів і телефонів: ті самі елементи, але у компактнішому компонуванні. */
+@media (max-width: 768px) {
+    .header {
+        min-height: 0;
+    }
+    .header_row {
+        display: block;
+        padding: 10px 0 12px;
+    }
+    .header_logo_wrap {
+        display: block;
+        text-align: center;
+        padding: 4px 0 8px;
+    }
+    .sub_text_logo {
+        display: block;
+        margin: 4px 0 0;
+        line-height: 18px;
+        text-align: center;
+    }
+    .header_controls_wrap,
+    .right_header_b {
+        float: none;
+        text-align: center;
+        padding: 0;
+        margin-top: 8px;
+    }
+    .header_controls_wrap br,
+    .right_header_b br {
+        display: none;
+    }
+    .search_b {
+        margin: 8px auto 0;
+        max-width: 360px;
+    }
+    .search_input {
+        width: 100%;
+    }
+    .language_select {
+        margin-bottom: 8px;
+    }
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {


### PR DESCRIPTION
### Motivation
- Оновити візуальний вигляд хедера на сайті, зберігши існуючий функціонал і розміри логотипа, та забезпечити приємну адаптивну презентацію на мобільних пристроях.
- Зробити мінімальні структурні правки в шаблоні, щоб полегшити сучасне компонування елементів без ризику зламати серверну логіку.

### Description
- Додано службові класи в шаблон `frontend/views/layouts/main/header.php`: `header_row`, `header_logo_wrap` і `header_controls_wrap`, зберігши логіку (на головній використовується `div`, на внутрішніх сторінках — `a`).
- Оновлено стилі в `frontend/web/css/main.css`: заміна фону на градієнт, додано `box-shadow`, покращені відступи і візуальна ієрархія для підпису під логотипом, а також плавні `transition` для поля пошуку.
- Збережено існуючі візуальні та функціональні елементи: логотип з тими самими розмірами `184x58`, мовний селектор і форма пошуку з CSRF та поточним механізмом сабміту.
- Додано адаптивні правила в CSS для `@media (max-width: 768px)`, щоб централізувати логотип і контролі, приховати технічні `<br>` та розтягнути пошук під ширину екрана; додано коментарі в PHP і CSS.

### Testing
- `php -l frontend/views/layouts/main/header.php` — синтаксична перевірка пройдена успішно (без помилок).
- Перевірено зміни локалізації змін через порівняння файлів (`frontend/views/layouts/main/header.php`, `frontend/web/css/main.css`) — зміни обмежені шаблоном хедера і стилями (перевірка виконана автоматично під час ревізії змін).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b725678c08324a8c7e512a8fb2572)