### PR TITLE
Оновлено дизайн хедера з адаптивною мобільною версією

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,27 +9,26 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header_row">
+            <?php // Для головної сторінки зберігаємо семантичну поведінку: логотип без посилання. ?>
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
+                <div class="logo">
+                    <?php // Залишаємо незмінні розміри логотипа (184x58), як було в старому дизайні. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
                 <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
-                    </span>
+                    <?php // Залишаємо незмінні розміри логотипа (184x58), як було в старому дизайні. ?>
+                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                    <span class="sub_text_logo"><?php echo Yii::t("main", 'кожен голос важливий'); ?></span>
                 </a>
             <?php endif; ?>
 
             <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
+                <div class="language_block">
+                    <?= WLanguageSelector::widget(); ?>
+                </div>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -127,24 +127,33 @@ a:hover {
 }
 .header {
     min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
-    border-bottom: 2px solid #147536;
+    background: linear-gradient(120deg, #0f5f2d 0%, #17793a 50%, #0f5f2d 100%);
+    border-bottom: 1px solid #0f5b2c;
+    box-shadow: 0 10px 24px rgba(7, 46, 22, 0.28);
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    margin-top: 0;
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
     text-decoration: none;
 }
 .sub_text_logo {
-    color: #fff;
+    color: #e8f6ed;
     display: inline-block;
     margin-left: 37px;
     line-height: 24px;
+    letter-spacing: 0.02em;
 }
 .right_header_b {
-    float: right;
+    margin-left: auto;
     text-align: right;
-    margin-top: 13px;
+    margin-top: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 10px;
 }
 .language_select {
     display: inline-block;
@@ -156,16 +165,20 @@ a.logo, div.logo {
     background: #dce6e4;
     margin-bottom: 10px;
 }
+.language_block .language_select {
+    margin-bottom: 0;
+}
 .language_select:hover,
 .language_select:focus {
     background: #fff;
 }
 .search_b {
     position: relative;
+    width: 320px;
 }
 .search_input {
     display: inline-block;
-    width: 300px;
+    width: 100%;
     height: 32px;
     border: 2px solid #147536;
     background: #f0f4f4;
@@ -187,6 +200,54 @@ a.logo, div.logo {
     background: url(/img/layout/search_icon.png);
     top: 10px;
     right: 10px;
+}
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 25px;
+    padding: 14px 15px;
+}
+
+/* Адаптивно перебудовуємо хедер для мобільної версії, не змінюючи функціонал. */
+@media (max-width: 767px) {
+    .header_row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px 15px 14px;
+    }
+
+    .right_header_b {
+        width: 100%;
+        align-items: stretch;
+    }
+
+    .language_block {
+        width: 100%;
+    }
+
+    .language_block .language_select {
+        width: 100%;
+    }
+
+    .search_b {
+        width: 100%;
+    }
+
+    .search_input {
+        height: 38px;
+        font-size: 15px;
+    }
+
+    .search_btn {
+        top: 12px;
+    }
+
+    .sub_text_logo {
+        margin-left: 6px;
+        line-height: 22px;
+    }
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {


### PR DESCRIPTION
### Motivation
- Поточний блок хедер виглядає застаріло і потребує сучасної візуальної рефакторингу з збереженням існуючого функціоналу.
- Потрібно зберегти всі наявні елементи (логотип, підпис, селектор мови, пошук) і точні розміри логотипа `184x58` згідно вимоги.
- Хедер має добре виглядати на мобільних пристроях і гармоніювати з загальним стилем сайту. 

### Description
- Перебудовано шаблон в `frontend/views/layouts/main/header.php`: додано обгортку `header_row`, блок `language_block` та коментарі українською, збережено логіку для головної/внутрішніх сторінок і розміри логотипа `184x58`.
- Оновлено стилі в `frontend/web/css/main.css`: замінено фонову графіку на градієнт, додано тінь, перехід на `flex`-розкладку для вирівнювання і покращених відступів.
- Додано адаптивні правила (`@media (max-width: 767px)`), щоб мовний селектор і поле пошуку ставали у стовпчик і займали доступну ширину на мобільних екранах.
- Змін не було у функціоналі селектора мови та форми пошуку; зміни лише у верстці і стилях, додано українські коментарі в коді.

### Testing
- `php -l frontend/views/layouts/main/header.php` — перевірка синтаксису пройшла успішно (без синтаксичних помилок).
- `git diff -- frontend/views/layouts/main/header.php frontend/web/css/main.css` — перевірка змін показала очікуваний набір правок у розмітці та стилях.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b725678c08324a8c7e512a8fb2572)