### PR TITLE
Оновити дизайн хедера — сучасний вигляд та адаптивність

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,9 +9,9 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <div class="row header__row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo" style="text-decoration: none;">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -127,38 +127,62 @@ a:hover {
 }
 .header {
     min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
-    border-bottom: 2px solid #147536;
+    /* Робимо хедер сучаснішим: глибший фон, м'які переходи та легкий ефект "скла". */
+    background:
+        radial-gradient(circle at 15% -80%, rgba(74, 203, 115, 0.34), transparent 48%),
+        radial-gradient(circle at 92% 10%, rgba(18, 110, 54, 0.38), transparent 36%),
+        linear-gradient(125deg, #0c7a3a 0%, #05662f 52%, #045128 100%);
+    border-bottom: 1px solid rgba(15, 96, 48, 0.85);
+    box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.12), 0 8px 20px rgba(4, 54, 27, 0.24);
+}
+.header__row {
+    /* Гнучкий контейнер зберігає поточний функціонал, але краще масштабується на мобільних. */
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    flex-wrap: wrap;
+    padding: 12px 0 14px;
 }
 a.logo, div.logo {
-    margin-top: 10px;
+    margin-top: 0;
     display: inline-block;
     text-decoration: none;
+    flex-shrink: 0;
 }
 .sub_text_logo {
-    color: #fff;
+    color: #e9fff1;
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    margin-top: 2px;
+    line-height: 20px;
+    font-size: 13px;
+    letter-spacing: 0.35px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
 }
 .right_header_b {
-    float: right;
+    float: none;
     text-align: right;
-    margin-top: 13px;
+    margin-top: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
 }
 .language_select {
     display: inline-block;
     width: 102px;
     height: 24px;
     line-height: 22px;
-    border: 1px solid #147536;
+    border: 1px solid rgba(11, 90, 45, 0.92);
     border-radius: 2px;
-    background: #dce6e4;
+    background: rgba(244, 251, 246, 0.95);
     margin-bottom: 10px;
+    box-shadow: 0 2px 8px rgba(5, 47, 23, 0.16);
 }
 .language_select:hover,
 .language_select:focus {
     background: #fff;
+    border-color: #3ac469;
 }
 .search_b {
     position: relative;
@@ -166,31 +190,71 @@ a.logo, div.logo {
 .search_input {
     display: inline-block;
     width: 300px;
-    height: 32px;
-    border: 2px solid #147536;
-    background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
-    color: #565656;
+    height: 38px;
+    border: 1px solid rgba(11, 95, 48, 0.88);
+    background: rgba(245, 252, 248, 0.98);
+    border-radius: 22px;
+    padding: 0 40px 0 14px;
+    color: #295341;
     outline: none;
+    transition: all 0.2s ease-in-out;
+    box-shadow: 0 4px 14px rgba(4, 61, 30, 0.16);
 }
 .search_input:hover,
 .search_input:focus {
     background: #fff;
     color: #000;
     border-color: #3ac469;
+    box-shadow: 0 6px 16px rgba(4, 61, 30, 0.2);
 }
 .search_btn {
     position: absolute;
     width: 14px;
     height: 13px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    top: 12px;
+    right: 14px;
+    opacity: 0.88;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+    opacity: 1;
+}
+
+/* Адаптивність: зберігаємо елементи і пропорції логотипу, але перебудовуємо композицію під мобільні екрани. */
+@media (max-width: 767px) {
+    .header {
+        min-height: auto;
+        padding: 0 0 10px;
+    }
+    .header__row {
+        display: block;
+        padding: 10px 0 4px;
+    }
+    a.logo, div.logo {
+        display: block;
+        text-align: center;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+        margin-top: 4px;
+        font-size: 12px;
+        line-height: 18px;
+    }
+    .right_header_b {
+        width: 100%;
+        align-items: stretch;
+        text-align: left;
+        margin-top: 8px;
+    }
+    .language_select {
+        margin-bottom: 10px;
+    }
+    .search_b,
+    .search_input {
+        width: 100%;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Хедер виглядав морально застарілим і потребував візуального оновлення при збереженні існуючого функціоналу та розмірів логотипу (`184x58`).
- Потрібно надати сучасний, чистий вигляд з кращою читабельністю і м’якими тінями, який гармоніюватиме з загальним стилем сайту. 
- Важливо забезпечити коректний і приємний вигляд на мобільних пристроях (`max-width: 767px`).

### Description
- Перебудовано розмітку хедера: додано контейнер `header__row` у `frontend/views/layouts/main/header.php` та прибрано зайвий інлайн-`margin-top`, зберігши структуру елементів і розмір логотипа (`184x58`).
- Оновлено стилі в `frontend/web/css/main.css`: заміна фону на багатошаровий градієнт, додано м’які тіні, зменшено контраст рамки, і додано коментарі з поясненнями рішень у CSS.
- Робоча композиція хедера переведена на flex-контейнер (`.header__row`), правий блок `right_header_b` став flex-контейнером, оновлено стиль вибору мови (`.language_select`) та оформлення поля пошуку (`.search_input`) у вигляді «pill», а іконка пошуку підлаштована позиційно.
- Додано адаптивні правила (`@media (max-width: 767px)`) для вертикального компонування, центрування логотипа та розтягнення поля пошуку по ширині екрану; зміни не торкаються бізнес-логіки.

### Testing
- Виконано синтакс-перевірку PHP файлу за командою `php -l frontend/views/layouts/main/header.php`, яка повернула помилок не виявлено (успішно).
- Зроблено локальний коміт і перевірено diff (`git diff`), змінені файли: `frontend/views/layouts/main/header.php` та `frontend/web/css/main.css` (операції гіта — успішні автоматичні перевірки).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b725678c08324a8c7e512a8fb2572)