### PR TITLE
Редизайн хедера: сучасний вигляд та покращена мобільна адаптація

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -7,36 +7,33 @@ use frontend\widgets\WSearchForm;
 <!-- ~/frontend/views/layouts/main/header.php -->
 <!-- Header
 ================================================== -->
-<header class="header">
+<header class="header header--rebuilt">
     <div class="container">
-        <div class="row">
+        <div class="row header__row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                <div class="logo header__logo" aria-label="Referendum Social home">
+                    <?php // Зберігаємо розмір логотипа без змін, щоб не ламати візуальну айдентику. ?>
+                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
-                <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
+                <a href="/" class="logo header__logo" aria-label="Referendum Social home">
+                    <?php // Зберігаємо розмір логотипа без змін, щоб не ламати візуальну айдентику. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
-                    </span>
+                    <span class="sub_text_logo"><?php echo Yii::t("main", 'кожен голос важливий'); ?></span>
                 </a>
             <?php endif; ?>
 
-            <div class="right_header_b">
-                <?= WLanguageSelector::widget(); ?>
-                <br>
+            <div class="right_header_b header__controls">
+                <div class="header__language"><?= WLanguageSelector::widget(); ?></div>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>
-                <div class="search_b">
-                    <form method="post" action="/site/search" name="HeaderSearch">
+                <div class="search_b header__search">
+                    <form method="post" action="/site/search" name="HeaderSearch" class="header__search-form">
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
                         <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">
+                        <?php // Тримаємо submit через посилання для повної сумісності зі старою версткою та подіями. ?>
                         <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
                         <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
                     </form>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -127,24 +127,59 @@ a:hover {
 }
 .header {
     min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
+    background: linear-gradient(135deg, #0d5c2f 0%, #147536 55%, #1e8645 100%);
     border-bottom: 2px solid #147536;
+    box-shadow: 0 8px 24px rgba(9, 53, 28, 0.22);
+}
+/* Оновлюємо шапку до сучасної «карткової» композиції, але залишаємо старі класи для сумісності. */
+.header--rebuilt {
+    position: relative;
+    overflow: hidden;
+}
+.header--rebuilt::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 88% 20%, rgba(255, 255, 255, 0.16), transparent 48%);
+    pointer-events: none;
+}
+.header__row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 18px;
+    min-height: 100px;
+    padding: 14px 0;
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    margin-top: 0;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
     text-decoration: none;
+    position: relative;
+    z-index: 1;
 }
 .sub_text_logo {
-    color: #fff;
+    color: #d7f5df;
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    margin-top: 2px;
+    line-height: 22px;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.18);
 }
 .right_header_b {
-    float: right;
+    float: none;
     text-align: right;
-    margin-top: 13px;
+    margin-top: 0;
+    position: relative;
+    z-index: 1;
+}
+.header__controls {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
 }
 .language_select {
     display: inline-block;
@@ -3899,4 +3934,45 @@ div.item_list_poll {
 }
 .bot_banner img {
     width: 100%;
+}
+
+/* Мобільна адаптація нової шапки: вертикальна композиція та повна ширина пошуку. */
+@media (max-width: 767px) {
+    .header {
+        min-height: auto;
+    }
+    .header__row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+        padding: 12px 0 14px;
+    }
+    a.logo, div.logo {
+        align-items: center;
+        text-align: center;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+        margin-top: 6px;
+    }
+    .header__controls,
+    .right_header_b {
+        width: 100%;
+        text-align: left;
+        align-items: stretch;
+    }
+    .header__language .language_select {
+        width: 100%;
+    }
+    .search_b,
+    .header__search-form,
+    .search_input {
+        width: 100%;
+    }
+    .search_input {
+        padding-right: 34px;
+    }
+    .search_btn {
+        right: 12px;
+    }
 }


### PR DESCRIPTION
### Motivation
- Поточний блок хедера візуально застарілий і потребував оновлення до більш сучасного та приємного для мобільних пристроїв вигляду. 
- Потрібно зберегти весь існуючий функціонал та візуальні елементи (логотип, слоган, мовний селектор, пошук) і не змінювати розмір логотипа. 

### Description
- Оновлено розмітку хедера у `frontend/views/layouts/main/header.php`: додано класи `header--rebuilt`, `header__row`, `header__controls`, `header__search-form`, видалено інлайнові стилі і додано коментарі для сумісності та читабельності. 
- Збережено розмір логотипа `184x58` і додано `aria-label` для кращої доступності, при цьому поведінка сабміту пошуку залишилась сумісною зі старою реалізацією. 
- Перенесено візуальні зміни в CSS у файл `frontend/web/css/main.css`: сучасний зелений градієнт фону, легка тінь, радіальна підсвітка, вирівнювання через Flexbox та нові стилі для слогану і контролів. 
- Додано адаптивні стилі для мобільних екранів (`@media (max-width: 767px)`), які переводять хедер у вертикальний стек, центрують логотип і розтягують селектор мови та пошук на повну ширину. 

### Testing
- Виконано синтаксичну перевірку PHP: `php -l frontend/views/layouts/main/header.php` — пройшло без помилок. 
- Перевірено різницю змін у файлах за допомогою `git diff` для контролю внесених правок; змінено `frontend/views/layouts/main/header.php` і `frontend/web/css/main.css`. 
- Автоматичних unit/integration тестів не змінювалось у цьому PR, тому додаткових тестів з `phpunit` не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b759999c48324ad156451b7836d3b)