### PR TITLE
Оновлення хедера: сучасний дизайн та покращена мобільна зручність

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,23 +9,25 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
-            <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
-                    <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
-                </div>
-            <?php else: ?>
-                <a href="/" class="logo">
-                    <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
-                    <span class="sub_text_logo">
-                        <?php echo Yii::t("main", 'кожен голос важливий'); ?>
-                    </span>
-                </a>
-            <?php endif; ?>
+        <div class="row header_row">
+            <div class="logo_b">
+                <?php if (Yii::$app->request->url == '/') : ?>
+                    <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                        <?php // Логотип зберігаємо у тих самих розмірах для візуальної тяглості бренду. ?>
+                        <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                        <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
+                    </div>
+                <?php else: ?>
+                    <a href="/" class="logo">
+                        <?php // Логотип зберігаємо у тих самих розмірах для візуальної тяглості бренду. ?>
+                        <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
+                        <br>
+                        <span class="sub_text_logo">
+                            <?php echo Yii::t("main", 'кожен голос важливий'); ?>
+                        </span>
+                    </a>
+                <?php endif; ?>
+            </div>
 
             <div class="right_header_b">
                 <?= WLanguageSelector::widget(); ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -127,11 +127,22 @@ a:hover {
 }
 .header {
     min-height: 100px;
-    background: url(/img/layout/header_bg.png) repeat;
+    background: linear-gradient(180deg, #1d7e43 0%, #146b36 100%);
     border-bottom: 2px solid #147536;
+    box-shadow: 0 3px 16px rgba(0, 0, 0, 0.2);
+}
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 14px 0;
+}
+.logo_b {
+    flex: 0 0 auto;
 }
 a.logo, div.logo {
-    margin-top: 10px;
+    margin-top: 0;
     display: inline-block;
     text-decoration: none;
 }
@@ -139,58 +150,104 @@ a.logo, div.logo {
     color: #fff;
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    margin-top: 2px;
+    line-height: 22px;
+    font-size: 14px;
+    letter-spacing: 0.2px;
+    opacity: 0.95;
 }
 .right_header_b {
-    float: right;
+    float: none;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
     text-align: right;
-    margin-top: 13px;
+    margin-top: 0;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
+    width: 164px;
+    min-height: 40px;
     border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    border-radius: 8px;
+    background: #e9f1ef;
+    margin-bottom: 12px;
+    padding: 0 10px;
+    color: #0a4a22;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
 }
 .language_select:hover,
 .language_select:focus {
     background: #fff;
+    outline: none;
+    border-color: #3ac469;
 }
 .search_b {
     position: relative;
 }
 .search_input {
     display: inline-block;
-    width: 300px;
-    height: 32px;
+    width: 320px;
+    min-height: 44px;
     border: 2px solid #147536;
-    background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    background: #f6faf9;
+    border-radius: 12px;
+    padding: 0 44px 0 14px;
     color: #565656;
     outline: none;
+    font-size: 15px;
 }
 .search_input:hover,
 .search_input:focus {
     background: #fff;
     color: #000;
     border-color: #3ac469;
+    box-shadow: 0 0 0 3px rgba(58, 196, 105, 0.2);
 }
 .search_btn {
     position: absolute;
-    width: 14px;
-    height: 13px;
+    width: 34px;
+    height: 34px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    background-repeat: no-repeat;
+    background-position: center;
+    top: 5px;
+    right: 6px;
+    border-radius: 50%;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+    background-repeat: no-repeat;
+    background-position: center;
+}
+@media (max-width: 767px) {
+    /* На мобільних перебудовуємо хедер у вертикальний стек для зручного натискання. */
+    .header_row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 14px;
+    }
+    .right_header_b {
+        width: 100%;
+        align-items: stretch;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+        max-width: 100%;
+    }
+    .language_select {
+        min-height: 44px;
+    }
+    .search_btn {
+        top: 6px;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Хедер виглядає застаріло і потребував сучасного візуального оновлення при збереженні поточної функціональності та розмірів логотипа. 
- Потрібно покращити зручність натискання на мобільних пристроях через більші інтерактивні зони та адаптивну компоновку.

### Description
- Перебудовано HTML-структуру хедера у `frontend/views/layouts/main/header.php` додаванням контейнерів `.header_row` і `.logo_b` та українськими коментарями, при цьому збережено віджет `WLanguageSelector` і форму пошуку. 
- Логотип збережено у тих самих розмірах `184x58` для візуальної тяглості бренду. 
- Оновлено стилі у `frontend/web/css/main.css`: замінено фон на градієнт, додано `box-shadow`, переведено розкладку на `flex` для гнучкого вирівнювання, підвищено розміри та скруглення для селектора мови та поля пошуку, змінено розміри і позицію іконки пошуку, додано покращені стани `:hover`/`:focus`. 
- Додано адаптивну секцію `@media (max-width: 767px)` для вертикального стеку елементів на мобільних пристроях, розтягнення контролів на 100% ширини та збільшених tap-target.

### Testing
- `php -l frontend/views/layouts/main/header.php` — синтаксичних помилок не виявлено (успішно). 
- `git status --short` — підтверджено змінені файли перед комітом (успішно). 
- `git commit` виконано для збереження змін (успішно). 
- Створено PR-опис автоматично через внутрішній `make_pr` (успішно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b78e1442883248fe8f44c5392e9a4)