### PR TITLE
Оновлення хедера: сучасний візуальний стиль і мобільна адаптивність

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,9 +9,10 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <?php // Додаємо гнучкий контейнер для сучаснішого компонування без зміни функціоналу. ?>
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
@@ -27,9 +28,10 @@ use frontend\widgets\WSearchForm;
                 </a>
             <?php endif; ?>
 
+            <?php // Групуємо мовний селектор і пошук у керований блок для адаптивного інтерфейсу. ?>
             <div class="right_header_b">
                 <?= WLanguageSelector::widget(); ?>
-                <br>
+                <?php // Прибираємо технічний перенос рядка, оскільки відступи контролюються стилями. ?>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -127,12 +127,22 @@ a:hover {
 }
 .header {
     min-height: 100px;
+    padding: 10px 0;
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
 }
+.header .row.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    flex-wrap: wrap;
+}
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    margin-top: 0;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
     text-decoration: none;
 }
 .sub_text_logo {
@@ -142,19 +152,26 @@ a.logo, div.logo {
     line-height: 24px;
 }
 .right_header_b {
-    float: right;
+    margin-top: 0;
+    margin-left: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
     text-align: right;
-    margin-top: 13px;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
+    min-width: 154px;
+    height: 36px;
+    line-height: 34px;
     border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    border-radius: 8px;
+    background: #eef5f2;
+    margin-bottom: 0;
+    padding: 0 10px;
+    color: #055C2B;
+    cursor: pointer;
 }
 .language_select:hover,
 .language_select:focus {
@@ -166,11 +183,11 @@ a.logo, div.logo {
 .search_input {
     display: inline-block;
     width: 300px;
-    height: 32px;
+    height: 40px;
     border: 2px solid #147536;
     background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    border-radius: 999px;
+    padding: 0 42px 0 14px;
     color: #565656;
     outline: none;
 }
@@ -182,15 +199,60 @@ a.logo, div.logo {
 }
 .search_btn {
     position: absolute;
-    width: 14px;
-    height: 13px;
+    width: 26px;
+    height: 26px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
+    background-repeat: no-repeat;
+    background-position: center;
+    top: 7px;
     right: 10px;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+    background-repeat: no-repeat;
+    background-position: center;
+}
+@media (max-width: 767px) {
+    /* Робимо хедер зручним для натискання та читання на телефонах. */
+    .header {
+        padding: 12px 0 14px;
+    }
+    .header .row.header_row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+    a.logo, div.logo {
+        align-items: center;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+        text-align: center;
+        width: 100%;
+        line-height: 20px;
+    }
+    .right_header_b {
+        margin-left: 0;
+        width: 100%;
+        align-items: stretch;
+        text-align: left;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+    }
+    .language_select {
+        min-width: 0;
+        height: 42px;
+        line-height: 40px;
+    }
+    .search_input {
+        height: 44px;
+    }
+    .search_btn {
+        top: 9px;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Блок хедера візуально застарів і потребував сучаснішого компонування та кращої зручності на мобільних пристроях.
- Потрібно зберегти поточний функціонал (перемикач мови, пошук, CSRF, submit) та розмір логотипа 184x58.
- Зміни повинні бути локальними та не зачіпати бекенд-логіку згідно принципу «не нашкодь». 

### Description
- Додано гнучкий контейнер `header_row` у шаблон `frontend/views/layouts/main/header.php` та коментарі українською для пояснення змін. 
- Оновлено CSS у `frontend/web/css/main.css`: перехід на flex-компонування, відступи, вирівнювання, стиль селектора мови, округлене поле пошуку та збільшені клікабельні зони.
- Додано медіа-правила `@media (max-width: 767px)` для вертикального розміщення елементів, розтягування контролів на ширину контейнера та збільшення висоти елементів для зручного тапу пальцем.
- Збережено існуючі візуальні елементи та розмір логотипа, зміни обмежені шаблоном хедера і CSS без зміни бізнес-логіки. 

### Testing
- Автоматична перевірка синтаксису PHP виконана командою `php -l frontend/views/layouts/main/header.php` і пройдена успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b78e1442883248fe8f44c5392e9a4)