### PR TITLE
Оновлено візуал хедера: адаптивний flex-layout і покращена мобільна зручність

### DIFF
--- a/frontend/views/layouts/main/header.php
+++ b/frontend/views/layouts/main/header.php
@@ -9,18 +9,18 @@ use frontend\widgets\WSearchForm;
 ================================================== -->
 <header class="header">
     <div class="container">
-        <div class="row">
+        <?php // Додаємо адаптивну сітку для сучаснішого вигляду та кращого UX на мобільних. ?>
+        <div class="row header_row">
             <?php if (Yii::$app->request->url == '/') : ?>
-                <div class="logo" style="margin-top: 10px; display: inline-block; text-decoration: none;">
+                <div class="logo" role="img" aria-label="referendum.social logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
-                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58"><br>
+                    <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
                     <span class="sub_text_logo"><?= Yii::t("main", 'кожен голос важливий'); ?></span>
                 </div>
             <?php else: ?>
                 <a href="/" class="logo">
                     <?php // Оновлюємо alt-текст логотипа для актуальної назви сайту. ?>
                     <img src="/img/layout/logo.png" alt="logo of website referendum.social" width="184" height="58">
-                    <br>
                     <span class="sub_text_logo">
                         <?php echo Yii::t("main", 'кожен голос важливий'); ?>
                     </span>
@@ -29,7 +29,6 @@ use frontend\widgets\WSearchForm;
 
             <div class="right_header_b">
                 <?= WLanguageSelector::widget(); ?>
-                <br>
 <?php /* * / ?>
                 <div class="search_b" style="border:1px dashed red;"><?= WSearchForm::widget([]); ?></div>
 <?php /* */ ?>
@@ -37,7 +36,8 @@ use frontend\widgets\WSearchForm;
                     <form method="post" action="/site/search" name="HeaderSearch">
                         <input type="hidden" name="<?= Yii::$app->request->csrfParam; ?>" value="<?= Yii::$app->request->csrfToken; ?>" />
                         <input class="search_input" type="search" name="SearchForm[text]" value="" placeholder="<?= Yii::t("main", 'Пошук'); ?>...">
-                        <a href="#" class="search_btn" onclick="document.forms['HeaderSearch'].submit()"></a>
+                        <?php // Використовуємо кнопку замість посилання для кращої доступності й натискань на телефоні. ?>
+                        <button type="submit" class="search_btn" aria-label="<?= Yii::t("main", 'Пошук'); ?>"></button>
                         <input type="checkbox" name="SearchForm[search_in_title]" checked hidden value="1">
                     </form>
                 </div>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -129,32 +129,45 @@ a:hover {
     min-height: 100px;
     background: url(/img/layout/header_bg.png) repeat;
     border-bottom: 2px solid #147536;
+    box-shadow: 0 6px 18px rgba(6, 80, 40, 0.18);
 }
 a.logo, div.logo {
-    margin-top: 10px;
-    display: inline-block;
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
     text-decoration: none;
+}
+.header_row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    padding: 10px 0;
 }
 .sub_text_logo {
     color: #fff;
     display: inline-block;
     margin-left: 37px;
-    line-height: 24px;
+    line-height: 20px;
 }
 .right_header_b {
-    float: right;
-    text-align: right;
-    margin-top: 13px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-wrap: wrap;
 }
 .language_select {
     display: inline-block;
-    width: 102px;
-    height: 24px;
-    line-height: 22px;
+    width: 150px;
+    height: 40px;
+    line-height: 38px;
     border: 1px solid #147536;
-    border-radius: 2px;
-    background: #dce6e4;
-    margin-bottom: 10px;
+    border-radius: 8px;
+    background: #edf4f2;
+    padding: 0 34px 0 12px;
+    cursor: pointer;
 }
 .language_select:hover,
 .language_select:focus {
@@ -166,11 +179,11 @@ a.logo, div.logo {
 .search_input {
     display: inline-block;
     width: 300px;
-    height: 32px;
+    height: 40px;
     border: 2px solid #147536;
     background: #f0f4f4;
-    border-radius: 4px;
-    padding-left: 12px;
+    border-radius: 20px;
+    padding: 0 44px 0 14px;
     color: #565656;
     outline: none;
 }
@@ -182,15 +195,45 @@ a.logo, div.logo {
 }
 .search_btn {
     position: absolute;
-    width: 14px;
-    height: 13px;
+    width: 24px;
+    height: 24px;
     background: url(/img/layout/search_icon.png);
-    top: 10px;
-    right: 10px;
+    border: 0;
+    top: 8px;
+    right: 12px;
+    cursor: pointer;
 }
 .search_input:hover ~ .search_btn,
 .search_input:focus ~ .search_btn {
     background: url(/img/layout/search_icon_hover.png);
+}
+/* Підвищуємо розміри та вертикальний стек для комфортного керування на смартфонах. */
+@media (max-width: 768px) {
+    .header {
+        padding-bottom: 8px;
+    }
+    .header_row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+    a.logo, div.logo {
+        align-items: center;
+    }
+    .sub_text_logo {
+        margin-left: 0;
+        text-align: center;
+    }
+    .right_header_b {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+    }
+    .language_select,
+    .search_input {
+        width: 100%;
+    }
 }
 .sub_header_slider_b {
     height: 81px;


### PR DESCRIPTION
### Motivation
- Поточний хедер виглядає візуально застарілим і потребує сучасного, більш зручного для мобільних оформлення.
- Потрібно зберегти увесь існуючий функціонал (логотип, слоган, мовний селектор, пошук) та розміри логотипа (184x58), але зробити інтерфейс більш гармонічним і touch‑friendly.
- Поліпшити доступність і семантику елементів для кращої взаємодії на смартфонах.

### Description
- Оновлено шаблон `frontend/views/layouts/main/header.php`: додано контейнер `header_row` на базі flex, прибрано зайвий `<br>`, додано `role="img"` для логотипа і `aria-label`, та замінено посилання для сабміту пошуку на семантичну кнопку `button type="submit"` з `aria-label`.
- Змінено стилі в `frontend/web/css/main.css`: перехід на flex‑верстку, додана м’яка тінь, оновлені радіуси і відступи для селектора мови і поля пошуку, збільшені цільові розміри елементів для touch‑інтеракцій.
- Додано адаптивну секцію `@media (max-width: 768px)` для вертикального стеку елементів, повних ширин інпутів і центрованого слогана на мобільних пристроях.
- У коді додано коментарі українською мовою згідно з внутрішніми інструкціями; логіка форми пошуку, CSRF і віджет селектора мови залишилися без змін.

### Testing
- `php -l frontend/views/layouts/main/header.php` — синтаксична перевірка пройдена успішно (без помилок).
- Ніяких unit/integration тестів у цьому патчі не запускалося, змінені лише шаблон і CSS, тому функціональні тести не були виконані.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b78e1442883248fe8f44c5392e9a4)