### PR TITLE
Додано публічний розділ новин `/news` з фільтрацією, сортуванням і пагінацією

### DIFF
--- a/frontend/config/main.php
+++ b/frontend/config/main.php
@@ -196,6 +196,9 @@ return [
 //                ],
 
                 'updates' => 'page/updates',
+                'news/page/<page:\d+>' => 'news/index',
+                'news/<slug:[\w-]+>' => 'news/view',
+                'news' => 'news/index',
                 // ВАЖЛИВО: ці "людські" URL мають бути вище за універсальне правило <page:[\w-]+>,
                 // інакше їх перехопить page/view.
                 'actual-polls' => 'poll/site/actual-polls',

--- a/frontend/controllers/NewsController.php
+++ b/frontend/controllers/NewsController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace frontend\controllers;
+
+use common\models\News;
+use Yii;
+use yii\data\Pagination;
+use yii\helpers\Url;
+use yii\web\Controller;
+
+class NewsController extends Controller
+{
+    public function actionIndex(int $page = 1)
+    {
+        $page = max(1, (int) $page);
+
+        // Не нашкодити: показуємо тільки опубліковані новини, дата яких вже настала.
+        $baseQuery = News::find()
+            ->where(['is_published' => 1])
+            ->andWhere(['<=', 'published_at', date('Y-m-d H:i:s')]);
+
+        $totalCount = (int) (clone $baseQuery)->count();
+        $pagination = new Pagination([
+            'totalCount' => $totalCount,
+            'pageSize' => 10,
+            'page' => $page - 1,
+            'route' => 'news/index',
+            'pageParam' => 'page',
+            'forcePageParam' => false,
+            'validatePage' => true,
+        ]);
+
+        $items = (clone $baseQuery)
+            // Сортуємо від найновіших до найстаріших.
+            ->orderBy(['published_at' => SORT_DESC, 'id' => SORT_DESC])
+            ->offset($pagination->offset)
+            ->limit($pagination->limit)
+            ->all();
+
+        $currentPage = $pagination->page + 1;
+        $this->registerPaginationMeta($pagination, $currentPage);
+
+        Yii::$app->page->setTitle('Новини | Referendum');
+        Yii::$app->page->setDescription('Останні новини Referendum: актуальні публікації, огляди та оновлення.');
+        $this->view->title = 'Новини | Referendum';
+
+        return $this->render('index', [
+            'items' => $items,
+            'pagination' => $pagination,
+        ]);
+    }
+
+    public function actionView(string $slug)
+    {
+        // Не нашкодити: відкриваємо лише публічні матеріали, доступні за датою.
+        $model = News::find()
+            ->where(['slug' => $slug, 'is_published' => 1])
+            ->andWhere(['<=', 'published_at', date('Y-m-d H:i:s')])
+            ->one();
+
+        if ($model === null) {
+            throw new \yii\web\NotFoundHttpException('Новину не знайдено.');
+        }
+
+        $canonicalUrl = Url::to(['/news/view', 'slug' => $model->slug], true);
+        Yii::$app->view->registerLinkTag([
+            'rel' => 'canonical',
+            'href' => $canonicalUrl,
+        ]);
+
+        $pageTitle = trim((string) $model->title) . ' | Новини Referendum';
+        Yii::$app->page->setTitle($pageTitle);
+        Yii::$app->page->setDescription(trim((string) ($model->desc ?: $model->excerpt)));
+        $this->view->title = $pageTitle;
+
+        return $this->render('view', ['model' => $model]);
+    }
+
+    private function registerPaginationMeta(Pagination $pagination, int $currentPage): void
+    {
+        $canonicalUrl = Url::to(['/news/index', 'page' => $currentPage > 1 ? $currentPage : null], true);
+        Yii::$app->view->registerLinkTag([
+            'rel' => 'canonical',
+            'href' => $canonicalUrl,
+        ]);
+
+        if ($currentPage > 1) {
+            $prevUrl = Url::to(['/news/index', 'page' => $currentPage - 1 > 1 ? $currentPage - 1 : null], true);
+            Yii::$app->view->registerLinkTag([
+                'rel' => 'prev',
+                'href' => $prevUrl,
+            ]);
+        }
+
+        $lastPage = (int) $pagination->getPageCount();
+        if ($currentPage < $lastPage) {
+            $nextUrl = Url::to(['/news/index', 'page' => $currentPage + 1], true);
+            Yii::$app->view->registerLinkTag([
+                'rel' => 'next',
+                'href' => $nextUrl,
+            ]);
+        }
+    }
+}

--- a/frontend/controllers/NewsController.php
+++ b/frontend/controllers/NewsController.php
@@ -29,10 +29,15 @@ class NewsController extends Controller
             'forcePageParam' => false,
             'validatePage' => true,
         ]);
-        // Не нашкодити: явно валідуємо номер сторінки й повертаємо 404 для page поза діапазоном.
-        if (!$pagination->setPage($page - 1, true)) {
+        // Не нашкодити: Pagination::setPage() не повертає bool, тому валідацію діапазону робимо явно.
+        $requestedPageZeroBased = $page - 1;
+        $pageCount = (int) $pagination->getPageCount();
+        // Для порожнього списку допускаємо лише першу сторінку; для непорожнього — 0..(pageCount-1).
+        $maxAllowedPageZeroBased = $pageCount > 0 ? $pageCount - 1 : 0;
+        if ($requestedPageZeroBased < 0 || $requestedPageZeroBased > $maxAllowedPageZeroBased) {
             throw new NotFoundHttpException('Сторінку новин не знайдено.');
         }
+        $pagination->setPage($requestedPageZeroBased, true);
 
         $items = (clone $baseQuery)
             // Сортуємо від найновіших до найстаріших.

--- a/frontend/controllers/NewsController.php
+++ b/frontend/controllers/NewsController.php
@@ -7,6 +7,7 @@ use Yii;
 use yii\data\Pagination;
 use yii\helpers\Url;
 use yii\web\Controller;
+use yii\web\NotFoundHttpException;
 
 class NewsController extends Controller
 {
@@ -23,12 +24,15 @@ class NewsController extends Controller
         $pagination = new Pagination([
             'totalCount' => $totalCount,
             'pageSize' => 10,
-            'page' => $page - 1,
             'route' => 'news/index',
             'pageParam' => 'page',
             'forcePageParam' => false,
             'validatePage' => true,
         ]);
+        // Не нашкодити: явно валідуємо номер сторінки й повертаємо 404 для page поза діапазоном.
+        if (!$pagination->setPage($page - 1, true)) {
+            throw new NotFoundHttpException('Сторінку новин не знайдено.');
+        }
 
         $items = (clone $baseQuery)
             // Сортуємо від найновіших до найстаріших.

--- a/frontend/controllers/NewsController.php
+++ b/frontend/controllers/NewsController.php
@@ -13,7 +13,12 @@ class NewsController extends Controller
 {
     public function actionIndex(int $page = 1)
     {
-        $page = max(1, (int) $page);
+        // Не нашкодити: не маскуємо невалідні page=0/000 як першу сторінку, а повертаємо 404.
+        $rawPage = (int) $page;
+        if ($rawPage < 1) {
+            throw new NotFoundHttpException('Сторінку новин не знайдено.');
+        }
+        $page = $rawPage;
 
         // Не нашкодити: показуємо тільки опубліковані новини, дата яких вже настала.
         $baseQuery = News::find()

--- a/frontend/views/news/index.php
+++ b/frontend/views/news/index.php
@@ -13,25 +13,32 @@ use yii\widgets\LinkPager;
         <h1 class="tag-page__title">Новини</h1>
 
         <?php if (!empty($items)): ?>
-            <?php foreach ($items as $item): ?>
-                <article class="chart_b" style="margin-bottom: 12px;">
-                    <h2 style="margin-top: 0;"><?= Html::encode($item->title); ?></h2>
-                    <div class="small text-muted" style="margin-bottom: 10px;">
-                        <?= Yii::$app->formatter->asDate($item->published_at, 'php:d.m.Y H:i'); ?>
-                    </div>
+            <div class="list_polls">
+                <?php foreach ($items as $item): ?>
+                    <article class="item_list_poll">
+                        <h2 class="item_list_poll__title" style="margin: 0 0 8px 0;">
+                            <?= Html::encode($item->title); ?>
+                        </h2>
+                        <div class="bottom_item_list_poll">
+                            <div class="bottom_item_list_poll__meta">
+                                <i class="fa fa-calendar" aria-hidden="true"></i>
+                                <?= Yii::$app->formatter->asDate($item->published_at, 'php:d.m.Y H:i'); ?>
+                            </div>
+                        </div>
 
-                    <?php
-                    // Якщо excerpt порожній, робимо безпечний короткий витяг із контенту.
-                    $excerpt = trim((string) $item->excerpt);
-                    if ($excerpt === '') {
-                        $excerpt = StringHelper::truncateWords(strip_tags((string) $item->content), 40);
-                    }
-                    ?>
-                    <p><?= Html::encode($excerpt); ?></p>
+                        <?php
+                        // Якщо excerpt порожній, робимо безпечний короткий витяг із контенту.
+                        $excerpt = trim((string) $item->excerpt);
+                        if ($excerpt === '') {
+                            $excerpt = StringHelper::truncateWords(strip_tags((string) $item->content), 40);
+                        }
+                        ?>
+                        <p style="margin: 8px 0 10px 0; color: #3d3d3d;"><?= Html::encode($excerpt); ?></p>
 
-                    <a href="<?= \yii\helpers\Url::to(['/news/view', 'slug' => $item->slug]); ?>" class="btn btn-default">Читати</a>
-                </article>
-            <?php endforeach; ?>
+                        <a href="<?= \yii\helpers\Url::to(['/news/view', 'slug' => $item->slug]); ?>" class="btn_prev_var">Читати</a>
+                    </article>
+                <?php endforeach; ?>
+            </div>
 
             <div class="text-center">
                 <?= LinkPager::widget([

--- a/frontend/views/news/index.php
+++ b/frontend/views/news/index.php
@@ -36,7 +36,7 @@ use yii\widgets\LinkPager;
             <div class="text-center">
                 <?= LinkPager::widget([
                     'pagination' => $pagination,
-                    'route' => 'news/index',
+                    // Не нашкодити: route задається у Pagination, тому не дублюємо тут.
                 ]); ?>
             </div>
         <?php else: ?>

--- a/frontend/views/news/index.php
+++ b/frontend/views/news/index.php
@@ -1,0 +1,48 @@
+<?php
+
+use yii\helpers\Html;
+use yii\helpers\StringHelper;
+use yii\widgets\LinkPager;
+
+/** @var yii\web\View $this */
+/** @var common\models\News[] $items */
+/** @var yii\data\Pagination $pagination */
+?>
+<div class="col-md-8">
+    <div class="row right_cut_row">
+        <h1 class="tag-page__title">Новини</h1>
+
+        <?php if (!empty($items)): ?>
+            <?php foreach ($items as $item): ?>
+                <article class="chart_b" style="margin-bottom: 12px;">
+                    <h2 style="margin-top: 0;"><?= Html::encode($item->title); ?></h2>
+                    <div class="small text-muted" style="margin-bottom: 10px;">
+                        <?= Yii::$app->formatter->asDate($item->published_at, 'php:d.m.Y H:i'); ?>
+                    </div>
+
+                    <?php
+                    // Якщо excerpt порожній, робимо безпечний короткий витяг із контенту.
+                    $excerpt = trim((string) $item->excerpt);
+                    if ($excerpt === '') {
+                        $excerpt = StringHelper::truncateWords(strip_tags((string) $item->content), 40);
+                    }
+                    ?>
+                    <p><?= Html::encode($excerpt); ?></p>
+
+                    <a href="<?= \yii\helpers\Url::to(['/news/view', 'slug' => $item->slug]); ?>" class="btn btn-default">Читати</a>
+                </article>
+            <?php endforeach; ?>
+
+            <div class="text-center">
+                <?= LinkPager::widget([
+                    'pagination' => $pagination,
+                    'route' => 'news/index',
+                ]); ?>
+            </div>
+        <?php else: ?>
+            <div class="chart_b">
+                <p style="margin: 0;">Поки що новин немає</p>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>

--- a/frontend/views/news/view.php
+++ b/frontend/views/news/view.php
@@ -1,0 +1,20 @@
+<?php
+
+use yii\helpers\Html;
+
+/** @var yii\web\View $this */
+/** @var common\models\News $model */
+?>
+<div class="col-md-8">
+    <div class="row right_cut_row">
+        <article class="chart_b">
+            <h1 class="tag-page__title"><?= Html::encode($model->h1 ?: $model->title); ?></h1>
+            <div class="small text-muted" style="margin-bottom: 12px;">
+                <?= Yii::$app->formatter->asDate($model->published_at, 'php:d.m.Y H:i'); ?>
+            </div>
+            <div class="news-content">
+                <?= $model->content; ?>
+            </div>
+        </article>
+    </div>
+</div>


### PR DESCRIPTION
### Motivation
- Додати публічний розділ новин, який показує тільки опубліковані матеріали доступні за датою, узгоджений зі стилем сайту і існуючою логікою пагінації для тегів. 
- Забезпечити коректні SEO-метатеги для сторінок пагінації (`canonical`, `prev`, `next`) щоб уникнути дублювання контенту.

### Description
- Додано правила маршрутизації в `frontend/config/main.php`: `news`, `news/page/<page:\d+>` і `news/<slug:[\w-]+>` розташовані перед універсальним правилом сторінок. 
- Створено `frontend/controllers/NewsController.php` з `actionIndex()` що фільтрує `is_published = 1` та `published_at <= now`, сортує за `published_at DESC`, та пагінує по 10 записів на сторінку з реєстрацією `canonical`, `prev` і `next` посилань. 
- Додано `actionView(string $slug)` у `NewsController` для перегляду одиночної новини, який теж показує тільки публічні записи і реєструє канонічну адресу. 
- Додано шаблони: `frontend/views/news/index.php` (карта новини з заголовком, датою, excerpt або витягом з контенту, кнопка «Читати», `LinkPager`, fallback «Поки що новин немає») і `frontend/views/news/view.php` для перегляду матеріалу. 

### Testing
- `php -l frontend/controllers/NewsController.php` — синтаксис без помилок. 
- `php -l frontend/views/news/index.php` — синтаксис без помилок. 
- `php -l frontend/views/news/view.php` — синтаксис без помилок. 
- `php -l frontend/config/main.php` — синтаксис без помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15fc1f9a1c83248fa3ed13b8834eda)