### PR TITLE
Додати вибір піддомену для новин

### DIFF
--- a/backend/modules/page/controllers/NewsController.php
+++ b/backend/modules/page/controllers/NewsController.php
@@ -52,6 +52,8 @@ class NewsController extends Controller
         if (!$this->request->isPost) {
             // Для нової форми підтягуємо значення за замовчуванням (чернетка), щоб не опублікувати новину випадково.
             $model->loadDefaultValues();
+            // Не нашкодити: якщо схема ще не віддала default, явно ставимо український піддомен як історичний базовий варіант.
+            $model->language_id = $model->language_id ?: 1;
         }
 
         return $this->render('create', ['model' => $model]);

--- a/backend/modules/page/views/news/_form.php
+++ b/backend/modules/page/views/news/_form.php
@@ -15,6 +15,8 @@ use yii\widgets\ActiveForm;
 
     <?= $form->field($model, 'title')->textInput(['maxlength' => true]) ?>
     <?= $form->field($model, 'slug')->textInput(['maxlength' => true]) ?>
+    <?php // Не нашкодити: редактор явно вибирає піддомен, щоб новина не з'явилась у неправильній мовній версії. ?>
+    <?= $form->field($model, 'language_id')->dropDownList(News::getSubdomainItems(), ['prompt' => 'Оберіть піддомен']) ?>
     <?= $form->field($model, 'h1')->textInput(['maxlength' => true]) ?>
     <?= $form->field($model, 'desc')->textarea(['rows' => 2]) ?>
     <?= $form->field($model, 'excerpt')->textarea(['rows' => 3]) ?>

--- a/backend/modules/page/views/news/index.php
+++ b/backend/modules/page/views/news/index.php
@@ -32,6 +32,13 @@ $this->params['breadcrumbs'][] = $this->title;
                 'label' => 'Заголовок',
             ],
             [
+                'attribute' => 'language_id',
+                'label' => 'Піддомен',
+                'filter' => News::getSubdomainItems(),
+                // Показуємо у гріді той самий підпис, що і в формі редагування.
+                'value' => static fn(News $model): string => News::getSubdomainItems()[$model->language_id] ?? '—',
+            ],
+            [
                 'attribute' => 'is_published',
                 'label' => 'Статус',
                 'filter' => News::getPublishedItems(),

--- a/common/models/News.php
+++ b/common/models/News.php
@@ -14,6 +14,7 @@ use yii\web\UploadedFile;
  * @property int $id
  * @property string $title
  * @property string $slug
+ * @property int $language_id
  * @property string|null $excerpt
  * @property string|null $content
  * @property string|null $image_url
@@ -25,6 +26,8 @@ use yii\web\UploadedFile;
  * @property int|null $updated_at
  * @property int|null $created_by
  * @property int|null $updated_by
+ *
+ * @property Language $language
  */
 class News extends ActiveRecord
 {
@@ -55,10 +58,10 @@ class News extends ActiveRecord
     public function rules(): array
     {
         return [
-            [['title', 'slug'], 'required'],
+            [['title', 'slug', 'language_id'], 'required'],
             [['excerpt', 'content', 'desc'], 'string'],
             [['published_at'], 'safe'],
-            [['is_published', 'created_at', 'updated_at', 'created_by', 'updated_by'], 'integer'],
+            [['language_id', 'is_published', 'created_at', 'updated_at', 'created_by', 'updated_by'], 'integer'],
             [['title', 'h1'], 'string', 'max' => 255],
             [['image_url'], 'string', 'max' => 1024],
             [
@@ -70,7 +73,9 @@ class News extends ActiveRecord
                 'skipOnEmpty' => true,
             ],
             [['slug'], 'string', 'max' => 128],
-            [['slug'], 'unique'],
+            // Slug має бути унікальним тільки в межах вибраного піддомену, щоб різні локалі не блокували одна одну.
+            [['slug', 'language_id'], 'unique', 'targetAttribute' => ['slug', 'language_id']],
+            [['language_id'], 'exist', 'skipOnError' => true, 'targetClass' => Language::class, 'targetAttribute' => ['language_id' => 'id']],
             [['is_published'], 'default', 'value' => 0],
             [['is_published'], 'in', 'range' => [0, 1]],
         ];
@@ -82,6 +87,7 @@ class News extends ActiveRecord
             'id' => 'ID',
             'title' => 'Заголовок',
             'slug' => 'Slug',
+            'language_id' => 'Піддомен',
             'excerpt' => 'Короткий опис',
             'content' => 'Контент',
             'image_url' => 'Зображення (URL)',
@@ -95,6 +101,50 @@ class News extends ActiveRecord
             'created_by' => 'Створив',
             'updated_by' => 'Оновив',
         ];
+    }
+
+    /**
+     * Повертає мову/піддомен, для якого призначена новина.
+     */
+    public function getLanguage()
+    {
+        return $this->hasOne(Language::class, ['id' => 'language_id']);
+    }
+
+    /**
+     * Формує список піддоменів для адмінки з урахуванням поточних мов у БД.
+     */
+    public static function getSubdomainItems(): array
+    {
+        $items = [];
+        $domains = Yii::$app->params['langDomains'] ?? [];
+        $languages = Language::find()->orderBy(['id' => SORT_ASC])->all();
+
+        foreach ($languages as $language) {
+            $domain = $domains[$language->id] ?? ($language->name . '.' . (defined('SITE_DOMAIN') ? SITE_DOMAIN : 'referendum.social'));
+            // Показуємо і піддомен, і країну, щоб редактор не переплутав мовну версію.
+            $items[$language->id] = $domain . ' — ' . Language::getCountryTitle($language);
+        }
+
+        return $items;
+    }
+
+    /**
+     * Визначає мовну версію поточного фронтенд-запиту для фільтрації новин.
+     */
+    public static function resolveCurrentLanguageId(): ?int
+    {
+        $request = Yii::$app->has('request') ? Yii::$app->request : null;
+        if ($request !== null && property_exists($request, 'languageId') && (int) $request->languageId > 0) {
+            return (int) $request->languageId;
+        }
+
+        $language = Language::find()->where(['locale' => Yii::$app->language])->one();
+        if ($language !== null) {
+            return (int) $language->id;
+        }
+
+        return null;
     }
 
 

--- a/common/models/search/NewsSearch.php
+++ b/common/models/search/NewsSearch.php
@@ -11,7 +11,7 @@ class NewsSearch extends News
     public function rules(): array
     {
         return [
-            [['id', 'is_published', 'created_at', 'updated_at'], 'integer'],
+            [['id', 'language_id', 'is_published', 'created_at', 'updated_at'], 'integer'],
             [['title', 'slug', 'excerpt', 'content', 'image_url', 'h1', 'desc', 'published_at'], 'safe'],
         ];
     }
@@ -37,6 +37,7 @@ class NewsSearch extends News
 
         $query->andFilterWhere([
             'id' => $this->id,
+            'language_id' => $this->language_id,
             'is_published' => $this->is_published,
             'published_at' => $this->published_at,
         ]);

--- a/console/migrations/m20260531_120000_add_language_id_to_news_table.php
+++ b/console/migrations/m20260531_120000_add_language_id_to_news_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use yii\db\Migration;
+
+class m20260531_120000_add_language_id_to_news_table extends Migration
+{
+    public function safeUp()
+    {
+        // Не нашкодити: наявні новини залишаємо на базовому українському піддомені.
+        $this->addColumn('{{%news}}', 'language_id', $this->integer()->unsigned()->notNull()->defaultValue(1)->after('slug')->comment('Language'));
+
+        if ($this->indexExists('{{%news}}', 'ux_news_slug')) {
+            $this->dropIndex('ux_news_slug', '{{%news}}');
+        }
+
+        $this->createIndex('idx_news_language_id', '{{%news}}', 'language_id');
+        $this->createIndex('ux_news_slug_language_id', '{{%news}}', ['slug', 'language_id'], true);
+        $this->addForeignKey('fk_news_language_id', '{{%news}}', 'language_id', '{{%language}}', 'id', 'RESTRICT', 'RESTRICT');
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_news_language_id', '{{%news}}');
+        $this->dropIndex('ux_news_slug_language_id', '{{%news}}');
+        $this->dropIndex('idx_news_language_id', '{{%news}}');
+        $this->dropColumn('{{%news}}', 'language_id');
+
+        // Повертаємо попереднє обмеження, якщо відкат справді потрібен.
+        $this->createIndex('ux_news_slug', '{{%news}}', 'slug', true);
+    }
+
+    private function indexExists(string $tableName, string $indexName): bool
+    {
+        if ($this->db->driverName !== 'mysql') {
+            // Для неміграційних тестових драйверів не робимо зайвих припущень про службові таблиці.
+            return true;
+        }
+
+        $rawTableName = $this->db->schema->getRawTableName($tableName);
+
+        return (bool) (new \yii\db\Query())
+            ->from('information_schema.STATISTICS')
+            ->where([
+                'TABLE_SCHEMA' => new \yii\db\Expression('DATABASE()'),
+                'TABLE_NAME' => $rawTableName,
+                'INDEX_NAME' => $indexName,
+            ])
+            ->exists($this->db);
+    }
+}

--- a/db/migrations/add_language_id_to_news.sql
+++ b/db/migrations/add_language_id_to_news.sql
@@ -1,0 +1,83 @@
+-- Не нашкодити: додаємо прив'язку новин до піддомену, не змінюючи наявний контент.
+SET @db_name := DATABASE();
+
+SET @has_language_id := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = @db_name
+      AND TABLE_NAME = 'news'
+      AND COLUMN_NAME = 'language_id'
+);
+SET @sql_add_language_id := IF(
+    @has_language_id = 0,
+    'ALTER TABLE `news` ADD COLUMN `language_id` int unsigned NOT NULL DEFAULT 1 AFTER `slug`',
+    'SELECT 1'
+);
+PREPARE stmt_add_language_id FROM @sql_add_language_id;
+EXECUTE stmt_add_language_id;
+DEALLOCATE PREPARE stmt_add_language_id;
+
+SET @has_old_slug_index := (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = @db_name
+      AND TABLE_NAME = 'news'
+      AND INDEX_NAME = 'ux_news_slug'
+);
+SET @sql_drop_old_slug_index := IF(
+    @has_old_slug_index > 0,
+    'ALTER TABLE `news` DROP INDEX `ux_news_slug`',
+    'SELECT 1'
+);
+PREPARE stmt_drop_old_slug_index FROM @sql_drop_old_slug_index;
+EXECUTE stmt_drop_old_slug_index;
+DEALLOCATE PREPARE stmt_drop_old_slug_index;
+
+SET @has_language_index := (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = @db_name
+      AND TABLE_NAME = 'news'
+      AND INDEX_NAME = 'idx_news_language_id'
+);
+SET @sql_language_index := IF(
+    @has_language_index = 0,
+    'ALTER TABLE `news` ADD INDEX `idx_news_language_id` (`language_id`)',
+    'SELECT 1'
+);
+PREPARE stmt_language_index FROM @sql_language_index;
+EXECUTE stmt_language_index;
+DEALLOCATE PREPARE stmt_language_index;
+
+SET @has_slug_language_index := (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = @db_name
+      AND TABLE_NAME = 'news'
+      AND INDEX_NAME = 'ux_news_slug_language_id'
+);
+SET @sql_slug_language_index := IF(
+    @has_slug_language_index = 0,
+    'ALTER TABLE `news` ADD UNIQUE INDEX `ux_news_slug_language_id` (`slug`, `language_id`)',
+    'SELECT 1'
+);
+PREPARE stmt_slug_language_index FROM @sql_slug_language_index;
+EXECUTE stmt_slug_language_index;
+DEALLOCATE PREPARE stmt_slug_language_index;
+
+SET @has_language_fk := (
+    SELECT COUNT(*)
+    FROM information_schema.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = @db_name
+      AND TABLE_NAME = 'news'
+      AND CONSTRAINT_NAME = 'fk_news_language_id'
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+);
+SET @sql_language_fk := IF(
+    @has_language_fk = 0,
+    'ALTER TABLE `news` ADD CONSTRAINT `fk_news_language_id` FOREIGN KEY (`language_id`) REFERENCES `language` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT',
+    'SELECT 1'
+);
+PREPARE stmt_language_fk FROM @sql_language_fk;
+EXECUTE stmt_language_fk;
+DEALLOCATE PREPARE stmt_language_fk;

--- a/db/migrations/create_news_table.sql
+++ b/db/migrations/create_news_table.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS `news` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL,
   `slug` varchar(128) NOT NULL,
+  `language_id` int unsigned NOT NULL DEFAULT 1,
   `excerpt` text DEFAULT NULL,
   `content` mediumtext DEFAULT NULL,
   `image_url` varchar(1024) DEFAULT NULL,
@@ -14,7 +15,9 @@ CREATE TABLE IF NOT EXISTS `news` (
   `created_by` int DEFAULT NULL,
   `updated_by` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `ux_news_slug` (`slug`),
+  UNIQUE KEY `ux_news_slug_language_id` (`slug`, `language_id`),
+  KEY `idx_news_language_id` (`language_id`),
   KEY `idx_news_published_at` (`published_at`),
-  KEY `idx_news_is_published` (`is_published`)
+  KEY `idx_news_is_published` (`is_published`),
+  CONSTRAINT `fk_news_language_id` FOREIGN KEY (`language_id`) REFERENCES `language` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/frontend/controllers/NewsController.php
+++ b/frontend/controllers/NewsController.php
@@ -20,10 +20,16 @@ class NewsController extends Controller
         }
         $page = $rawPage;
 
-        // Не нашкодити: показуємо тільки опубліковані новини, дата яких вже настала.
+        $languageId = News::resolveCurrentLanguageId();
+
+        // Не нашкодити: показуємо тільки опубліковані новини поточного піддомену, дата яких вже настала.
         $baseQuery = News::find()
             ->where(['is_published' => 1])
             ->andWhere(['<=', 'published_at', date('Y-m-d H:i:s')]);
+        if ($languageId !== null) {
+            // Фільтр за піддоменом не дає новинам з інших мовних версій потрапити у список.
+            $baseQuery->andWhere(['language_id' => $languageId]);
+        }
 
         $totalCount = (int) (clone $baseQuery)->count();
         $pagination = new Pagination([
@@ -68,11 +74,17 @@ class NewsController extends Controller
 
     public function actionView(string $slug)
     {
-        // Не нашкодити: відкриваємо лише публічні матеріали, доступні за датою.
-        $model = News::find()
+        $languageId = News::resolveCurrentLanguageId();
+
+        // Не нашкодити: відкриваємо лише публічні матеріали поточного піддомену, доступні за датою.
+        $query = News::find()
             ->where(['slug' => $slug, 'is_published' => 1])
-            ->andWhere(['<=', 'published_at', date('Y-m-d H:i:s')])
-            ->one();
+            ->andWhere(['<=', 'published_at', date('Y-m-d H:i:s')]);
+        if ($languageId !== null) {
+            // Такий самий фільтр, як у списку, щоб однакові slug могли існувати на різних піддоменах.
+            $query->andWhere(['language_id' => $languageId]);
+        }
+        $model = $query->one();
 
         if ($model === null) {
             throw new \yii\web\NotFoundHttpException(Yii::t('poll', 'Новину не знайдено.'));


### PR DESCRIPTION
### Motivation
- Додати можливість у адмінці явно вказувати для якого піддомену/мовної версії призначена новина, щоб однакові `slug` могли існувати для різних локалей і на фронтенді показувалися тільки релевантні матеріали.
- Зберегти поточний контент без змін, прив'язавши існуючі записи до історичного українського піддомену за замовчуванням, та уникнути регресій у пошуку/фільтрації.

### Description
- Додано поле `language_id` в модель `News` із валідацією, зв'язком `getLanguage()`, унікальністю `slug` в межах `language_id` і допоміжними методами `getSubdomainItems()` і `resolveCurrentLanguageId()` у `common/models/News.php`.
- Додано міграцію `console/migrations/m20260531_120000_add_language_id_to_news_table.php` і SQL-скрипт `db/migrations/add_language_id_to_news.sql`, оновлено `db/migrations/create_news_table.sql` для включення `language_id`, індексів та FK.
- Оновлено адмінську форму та список новин для вибору/фільтрації піддомену: `backend/modules/page/views/news/_form.php` та `backend/modules/page/views/news/index.php`, і встановлено дефолт `language_id` у контролері адмінки `backend/modules/page/controllers/NewsController.php`.
- Оновлено пошук у адмінці `common/models/search/NewsSearch.php` та фронтенд-логіку (`frontend/controllers/NewsController.php`) для фільтрації списку й перегляду новин поточним піддоменом.

### Testing
- Перевірка синтаксису: `php -l` для змінених PHP-файлів пройшла успішно.
- Перевірка конфігурації пакета: `composer validate --no-check-publish` виконалась успішно, було виведено кілька попереджень про незв'язані версії залежностей.
- Перевірка дифів: `git diff --check` не виявив проблем із пробілами/форматом.
- PHPUnit не було запущено у CI через відсутність `vendor/bin/phpunit` у поточному середовищі, тож автоматичні тести не виконувалися.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cb225cecc83329aa868d8a39c75d1)