### PR TITLE
Add aria-labels and convert poll share links to buttons for accessibility

### DIFF
--- a/common/messages/en-NZ/poll.php
+++ b/common/messages/en-NZ/poll.php
@@ -82,6 +82,12 @@ Registration on the site is required not only to see the results of surveys, but
         'до'=>'to',
         'Закрите до кількості голосів'=>'Closed until the number of votes:',
         'Посилання скопійовано' => 'Link copied',
+        // aria-label для кнопок поширення, щоб англомовні сторінки не показували український текст.
+        'Поділитися у Facebook' => 'Share on Facebook',
+        'Поділитися у VK' => 'Share on VK',
+        'Поділитися у Twitter' => 'Share on Twitter',
+        'Поділитися у Google Plus' => 'Share on Google Plus',
+        'Скопіювати посилання' => 'Copy link',
         'ЗБЕРЕГТИ'=>'SAVE',
     'Рейтинг користувача' => 'User rating',
     'Всього опитувань' => 'Total polls',

--- a/common/messages/en-US/poll.php
+++ b/common/messages/en-US/poll.php
@@ -79,6 +79,12 @@ Registration on the site is required not only to see the results of surveys, but
         'до'=>'to',
         'Закрите до кількості голосів'=>'Closed until the number of votes:',
         'Посилання скопійовано' => 'Link copied',
+        // aria-label для кнопок поширення, щоб англомовні сторінки не показували український текст.
+        'Поділитися у Facebook' => 'Share on Facebook',
+        'Поділитися у VK' => 'Share on VK',
+        'Поділитися у Twitter' => 'Share on Twitter',
+        'Поділитися у Google Plus' => 'Share on Google Plus',
+        'Скопіювати посилання' => 'Copy link',
         'ЗБЕРЕГТИ'=>'SAVE',
     'Рейтинг користувача' => 'User rating',
     'Всього опитувань' => 'Total polls',

--- a/frontend/views/site/polls/_shareSocial.php
+++ b/frontend/views/site/polls/_shareSocial.php
@@ -11,6 +11,12 @@ $pollDescribe = preg_replace('/([^\pL\pN\pP\pS\pZ])|([\xC2\xA0])/u', ' ', $pollD
 $pollDescribe = str_replace('  ',' ', $pollDescribe);
 $pollDescribe = trim($pollDescribe);
 $copyMessage = Yii::t('poll', 'Посилання скопійовано');
+// Тексти aria-label пояснюють дію іконкових кнопок для скринрідерів.
+$facebookLabel = Yii::t('poll', 'Поділитися у Facebook');
+$vkLabel = Yii::t('poll', 'Поділитися у VK');
+$twitterLabel = Yii::t('poll', 'Поділитися у Twitter');
+$googleLabel = Yii::t('poll', 'Поділитися у Google Plus');
+$copyLabel = Yii::t('poll', 'Скопіювати посилання');
 // Формуємо URL логотипу для соцмереж з поточного домену/субдомену.
 $socialLogoUrl = Yii::$app->request->hostInfo . '/img/layout/logo_social.png';
 
@@ -20,28 +26,28 @@ $socialLogoUrl = Yii::$app->request->hostInfo . '/img/layout/logo_social.png';
 </span>
 <span class="links_share">
     <span class="inner_b_share">
-        <a href="javascript:void(0)" class="facebook icon_share"
+        <button type="button" class="facebook icon_share" aria-label="<?= Html::encode($facebookLabel); ?>"
            onclick="Share.facebook('<?php echo $url; ?>','<?= Html::encode ($poll->title); ?>','<?= Html::encode($socialLogoUrl); ?>','<?= Html::encode ($describe); ?>')">
             <i class="fa fa-facebook"></i>
-        </a>
+        </button>
 <?php /* * /?>
-        <a href="javascript:void(0)" class="vk icon_share"
+        <button type="button" class="vk icon_share" aria-label="<?= Html::encode($vkLabel); ?>"
            onclick="Share.vkontakte('<?php echo $url; ?>','<?= Html::encode ($poll->title); ?>','<?= Html::encode($socialLogoUrl); ?>','<?= Html::encode ($pollDescribe); ?>')">
             <i class="fa fa-vk"></i>
-        </a>
+        </button>
 <?php /* */?>
-        <a href="javascript:void(0)" class="twitter icon_share"
+        <button type="button" class="twitter icon_share" aria-label="<?= Html::encode($twitterLabel); ?>"
            onclick="Share.twitter('<?php echo $url; ?>','<?= Html::encode ($poll->title); ?>')">
             <i class="fa fa-twitter"></i>
-        </a>
+        </button>
 <?php /* * /?>
-        <a href="javascript:void(0)" class="google icon_share" onclick="Share.gg('<?php echo $url; ?>')">
+        <button type="button" class="google icon_share" aria-label="<?= Html::encode($googleLabel); ?>" onclick="Share.gg('<?php echo $url; ?>')">
             <i class="fa fa-google-plus"></i>
-        </a>
+        </button>
 <?php /* */?>
-        <a href="javascript:void(0)" class="copy_link icon_share" data-url="<?php echo $url; ?>">
+        <button type="button" class="copy_link icon_share" aria-label="<?= Html::encode($copyLabel); ?>" data-url="<?php echo $url; ?>">
             <i class="fa fa-link"></i>
-        </a>
+        </button>
     </span>
 </span>
 <span class="copy_link_message"><?= Html::encode($copyMessage); ?></span>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -642,11 +642,18 @@ a.link_poll:hover {
     display: inline-block;
     vertical-align: middle;
     width: 100%;
+    /* Прибираємо стандартний вигляд button, щоб заміна посилань не змінила дизайн. */
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: center;
     /* Масштабуємо іконки всередині списку на 25%. */
     height: 35px;
     font-size: 17.5px;
     color: #000;
-    padding-top: 6.25px;
+    padding: 6.25px 0 0;
+    box-sizing: border-box;
 }
 .icon_share.facebook {
     color: #3b5998;

--- a/frontend/widgets/views/poll-list.php
+++ b/frontend/widgets/views/poll-list.php
@@ -324,12 +324,12 @@ if ($category === 'own') {
 </span>
 <span class="links_share">
     <span class="inner_b_share">
-        <a href="javascript:void(0)" class="facebook icon_share" onclick="Share.facebook('http://en.online-statistics.org.local/#P#/poll/382','Do you think that Trump is Traitor? ','<?= Html::encode($socialLogoUrl); ?>','Варіанти відповіді: Yes No I doubt ')">
+        <button type="button" class="facebook icon_share" aria-label="Поділитися у Facebook" onclick="Share.facebook('http://en.online-statistics.org.local/#P#/poll/382','Do you think that Trump is Traitor? ','<?= Html::encode($socialLogoUrl); ?>','Варіанти відповіді: Yes No I doubt ')">
             <i class="fa fa-facebook"></i>
-        </a>
-        <a href="javascript:void(0)" class="twitter icon_share" onclick="Share.twitter('http://en.online-statistics.org.local/#P#/poll/382','Do you think that Trump is Traitor? ')">
+        </button>
+        <button type="button" class="twitter icon_share" aria-label="Поділитися у Twitter" onclick="Share.twitter('http://en.online-statistics.org.local/#P#/poll/382','Do you think that Trump is Traitor? ')">
             <i class="fa fa-twitter"></i>
-        </a>
+        </button>
     </span>
 </span>                </span>
 
@@ -379,12 +379,12 @@ if ($category === 'own') {
 </span>
 <span class="links_share">
     <span class="inner_b_share">
-        <a href="javascript:void(0)" class="facebook icon_share" onclick="Share.facebook('http://en.online-statistics.org.local/#P#/poll/383','Do you think, that Trump Will go to Prison?','<?= Html::encode($socialLogoUrl); ?>','Варіанти відповіді: Yes No ')">
+        <button type="button" class="facebook icon_share" aria-label="Поділитися у Facebook" onclick="Share.facebook('http://en.online-statistics.org.local/#P#/poll/383','Do you think, that Trump Will go to Prison?','<?= Html::encode($socialLogoUrl); ?>','Варіанти відповіді: Yes No ')">
             <i class="fa fa-facebook"></i>
-        </a>
-        <a href="javascript:void(0)" class="twitter icon_share" onclick="Share.twitter('http://en.online-statistics.org.local/#P#/poll/383','Do you think, that Trump Will go to Prison?')">
+        </button>
+        <button type="button" class="twitter icon_share" aria-label="Поділитися у Twitter" onclick="Share.twitter('http://en.online-statistics.org.local/#P#/poll/383','Do you think, that Trump Will go to Prison?')">
             <i class="fa fa-twitter"></i>
-        </a>
+        </button>
     </span>
 </span>                </span>
 
@@ -452,12 +452,12 @@ if ($category === 'own') {
 </span>
 <span class="links_share">
     <span class="inner_b_share">
-        <a href="javascript:void(0)" class="facebook icon_share" onclick="Share.facebook('http://en.online-statistics.org.local/#P#/poll/401','Do you stand with Steve Bannon? ','<?= Html::encode($socialLogoUrl); ?>','Варіанти відповіді: Yes No ')">
+        <button type="button" class="facebook icon_share" aria-label="Поділитися у Facebook" onclick="Share.facebook('http://en.online-statistics.org.local/#P#/poll/401','Do you stand with Steve Bannon? ','<?= Html::encode($socialLogoUrl); ?>','Варіанти відповіді: Yes No ')">
             <i class="fa fa-facebook"></i>
-        </a>
-        <a href="javascript:void(0)" class="twitter icon_share" onclick="Share.twitter('http://en.online-statistics.org.local/#P#/poll/401','Do you stand with Steve Bannon? ')">
+        </button>
+        <button type="button" class="twitter icon_share" aria-label="Поділитися у Twitter" onclick="Share.twitter('http://en.online-statistics.org.local/#P#/poll/401','Do you stand with Steve Bannon? ')">
             <i class="fa fa-twitter"></i>
-        </a>
+        </button>
     </span>
 </span>                </span>
 


### PR DESCRIPTION
### Motivation
- Improve accessibility of poll sharing controls so screen readers receive meaningful labels and English locales do not show Ukrainian text. 
- Use semantic `button` elements for interactive share controls instead of anchor tags to better reflect their behavior and avoid navigation side effects.

### Description
- Added translation keys for share controls (`Поділитися у Facebook`, `Поділитися у VK`, `Поділитися у Twitter`, `Поділитися у Google Plus`, `Скопіювати посилання`) to `common/messages/en-NZ/poll.php` and `common/messages/en-US/poll.php` so English locales render appropriate aria text. 
- Updated `frontend/views/site/polls/_shareSocial.php` to obtain localized labels via `Yii::t`, add `aria-label` attributes, and replace `<a>` share links with `<button type="button">` elements. 
- Replaced share anchor elements with `button` elements and added `aria-label` attributes in `frontend/widgets/views/poll-list.php` so list items match the share control behavior. 
- Adjusted `frontend/web/css/main.css` to remove default `button` appearance (border/background), preserve original layout (`box-sizing`, padding, cursor, font inheritance) and ensure icons keep intended sizing and alignment.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d4896d94c8332a2696239767003e1)