### PR TITLE
Додати лінійний графік (Highcharts) для сторінок опитувань

### DIFF
--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -7,6 +7,7 @@ use common\components\ActiveRecord;
 use common\helpers\StringHelper;
 use yii\bootstrap\Html;
 use yii\db\Expression;
+use yii\db\Query;
 
 /**
  * This is the model class for table "{{%poll}}".
@@ -1091,6 +1092,142 @@ class Poll extends ActiveRecord
                 $pollTag->save();
             }
         }
+    }
+
+    /**
+     * Return cumulative percentage history for the Highcharts line chart.
+     *
+     * Лінійний графік показує, як змінювалась частка кожного варіанта за днями голосування.
+     * Для демографічних фільтрів беремо тільки зареєстрованих користувачів, бо гостьові голоси
+     * не мають профілю з країною, статтю або віком.
+     */
+    public function getLineChartData($sex = 0, $ageInterval = 0, $country = 0, $registration = 0)
+    {
+        $options = $this->pollOptions;
+        $optionTitles = [];
+        $dailyVotes = [];
+        $dates = [];
+
+        foreach ($options as $option) {
+            $optionTitles[(int)$option->id] = $option->title;
+            $dailyVotes[(int)$option->id] = [];
+        }
+
+        if (empty($optionTitles)) {
+            return ['categories' => [], 'series' => []];
+        }
+
+        if ($ageInterval) {
+            $age = User::getAgesByIntervalIndex($ageInterval);
+        }
+
+        $hasProfileFilters = $sex || isset($age) || $country;
+        $optionIds = array_keys($optionTitles);
+
+        if ($registration !== 2) {
+            $registeredQuery = (new Query())
+                ->select([
+                    'option_id' => 'ov.option_id',
+                    'vote_date' => new Expression('DATE(ov.date_add)'),
+                    'votes' => new Expression('COUNT(*)'),
+                ])
+                ->from(['ov' => OptionVote::tableName()])
+                ->leftJoin(['p' => Profile::tableName()], 'p.user_id = ov.user_id')
+                ->where(['ov.option_id' => $optionIds])
+                ->andWhere(['not', ['ov.user_id' => null]]);
+
+            if ($country) {
+                $registeredQuery->andWhere(['p.country_id' => $country]);
+            }
+
+            if ($sex) {
+                $registeredQuery->andWhere(['p.gender' => $sex]);
+            }
+
+            if (isset($age)) {
+                $registeredQuery->andWhere(new Expression('YEAR(CURDATE())-YEAR(p.date_birthday) BETWEEN :min AND :max', [
+                    ':min' => $age['min'],
+                    ':max' => $age['max'],
+                ]));
+            }
+
+            $this->appendLineChartRows($registeredQuery
+                ->groupBy(['ov.option_id', new Expression('DATE(ov.date_add)')])
+                ->all(), $dailyVotes, $dates);
+        }
+
+        if (!$hasProfileFilters && $registration !== 1) {
+            $guestQuery = (new Query())
+                ->select([
+                    'option_id' => 'ogv.option_id',
+                    'vote_date' => new Expression('DATE(ogv.date_add)'),
+                    'votes' => new Expression('COUNT(*)'),
+                ])
+                ->from(['ogv' => OptionGuestVote::tableName()])
+                ->where(['ogv.option_id' => $optionIds])
+                ->groupBy(['ogv.option_id', new Expression('DATE(ogv.date_add)')]);
+
+            $this->appendLineChartRows($guestQuery->all(), $dailyVotes, $dates);
+        }
+
+        sort($dates);
+
+        return $this->buildLineChartPercentSeries($optionTitles, $dailyVotes, $dates);
+    }
+
+    /**
+     * Додає згруповані голоси у спільний масив, щоб зареєстровані й гостьові голоси сумувались.
+     */
+    private function appendLineChartRows(array $rows, array &$dailyVotes, array &$dates)
+    {
+        foreach ($rows as $row) {
+            $optionId = (int)$row['option_id'];
+            $date = (string)$row['vote_date'];
+
+            if ($date === '' || !isset($dailyVotes[$optionId])) {
+                continue;
+            }
+
+            if (!isset($dailyVotes[$optionId][$date])) {
+                $dailyVotes[$optionId][$date] = 0;
+            }
+
+            $dailyVotes[$optionId][$date] += (int)$row['votes'];
+            $dates[$date] = $date;
+        }
+    }
+
+    /**
+     * Перетворює щоденні голоси на накопичувальні відсотки для Highcharts line.
+     */
+    private function buildLineChartPercentSeries(array $optionTitles, array $dailyVotes, array $dates)
+    {
+        $series = [];
+        $runningTotals = array_fill_keys(array_keys($optionTitles), 0);
+
+        foreach ($optionTitles as $optionId => $title) {
+            $series[$optionId] = ['name' => $title, 'data' => []];
+        }
+
+        foreach ($dates as $date) {
+            $totalForDate = 0;
+
+            foreach ($optionTitles as $optionId => $title) {
+                $runningTotals[$optionId] += $dailyVotes[$optionId][$date] ?? 0;
+                $totalForDate += $runningTotals[$optionId];
+            }
+
+            foreach ($optionTitles as $optionId => $title) {
+                $series[$optionId]['data'][] = $totalForDate > 0
+                    ? round($runningTotals[$optionId] * 100 / $totalForDate, 1)
+                    : 0;
+            }
+        }
+
+        return [
+            'categories' => array_values($dates),
+            'series' => array_values($series),
+        ];
     }
 
     /*

--- a/frontend/modules/ajax/views/modal/create-poll-step-one.php
+++ b/frontend/modules/ajax/views/modal/create-poll-step-one.php
@@ -134,12 +134,15 @@ $model = $pollModel;
                             <li class="<?php if (!$model->result_type || $model->result_type == 1): ?>active<?php endif; ?>"><input id="type_1" type="radio" name="Poll[type]" value="1" <?php if (!$model->result_type || $model->result_type == 1): ?>checked<?php endif; ?> hidden><a href="#horizontal_b_chart" class="horizontal_b_chart" role="tab" data-toggle="tab"></a></li>
                             <li class="<?php if ($model->result_type == 2): ?>active<?php endif; ?>"><input id="type_2" type="radio" name="Poll[type]" value="2" <?php if ($model->result_type == 2): ?>checked<?php endif; ?> hidden><a href="#vertical_b_chart" class="vertical_b_chart" role="tab" data-toggle="tab"></a></li>
                             <li class="<?php if ($model->result_type == 3): ?>active<?php endif; ?>"><input id="type_3" type="radio" name="Poll[type]" value="3" <?php if ($model->result_type == 3): ?>checked<?php endif; ?> hidden><a href="#pie_chart" class="pie_chart" role="tab" data-toggle="tab"></a></li>
+                            <?php // Додаємо лінійний графік як четвертий тип результатів опитування. ?>
+                            <li class="<?php if ($model->result_type == 4): ?>active<?php endif; ?>"><input id="type_4" type="radio" name="Poll[type]" value="4" <?php if ($model->result_type == 4): ?>checked<?php endif; ?> hidden><a href="#line_chart" class="line_chart" role="tab" data-toggle="tab"></a></li>
                         </ul>
                     </div>
                     <div class="tab-content tab_visual">
                         <div id="horizontal_b_chart" class="tab-pane <?php if (!$model->result_type || $model->result_type == 1): ?>active<?php endif; ?>" style="width:500px; height:400px;"></div>
                         <div id="vertical_b_chart" class="tab-pane <?php if ($model->result_type == 2): ?>active<?php endif; ?>" style="width:500px; height:400px;"></div>
                         <div id="pie_chart" class="tab-pane <?php if ($model->result_type == 3): ?>active<?php endif; ?>" style="width:500px; height:400px;"></div>
+                        <div id="line_chart" class="tab-pane <?php if ($model->result_type == 4): ?>active<?php endif; ?>" style="width:500px; height:400px;"></div>
                     </div>
                 </div>
             </div>
@@ -361,8 +364,8 @@ JS_POLL_ONE;
   filterDataChart({$poll->id},'{$poll->title}');
   });
 
-  $(document).on('click','.pie_chart,.horizontal_b_chart,.vertical_b_chart',function(){
-  $('#container{$poll->id}').removeClass('pie').removeClass('bar').removeClass('column');
+  $(document).on('click','.pie_chart,.horizontal_b_chart,.vertical_b_chart,.line_chart',function(){
+  $('#container{$poll->id}').removeClass('pie').removeClass('bar').removeClass('column').removeClass('line');
   $('#container{$poll->id}').addClass($(this).attr('data-id'));
   filterDataChart({$poll->id},'{$poll->title}');
   });

--- a/frontend/modules/poll/controllers/AjaxController.php
+++ b/frontend/modules/poll/controllers/AjaxController.php
@@ -65,6 +65,8 @@ class AjaxController extends \yii\web\Controller
                     $chartData = $poll->getChartData($gender,$ageInterval,$country,$registration);
                     $result['bar'] = StringHelper::formatForBarAjax($chartData);
                     $result['pie'] = StringHelper::formatForPieAjax($chartData);
+                    // Лінійний графік використовує ті самі фільтри, але повертає історію часток за датами.
+                    $result['line'] = $poll->getLineChartData($gender,$ageInterval,$country,$registration);
                     echo json_encode($result);
                     die();
                     return $result;

--- a/frontend/modules/poll/controllers/PollController.php
+++ b/frontend/modules/poll/controllers/PollController.php
@@ -446,6 +446,8 @@ class PollController extends \yii\web\Controller
                     $chartData = $poll->getChartData($gender,$ageInterval,$country,$registration);
                     $result['bar'] = StringHelper::formatForBarAjax($chartData);
                     $result['pie'] = StringHelper::formatForPieAjax($chartData);
+                    // Лінійний графік використовує ті самі фільтри, але повертає історію часток за датами.
+                    $result['line'] = $poll->getLineChartData($gender,$ageInterval,$country,$registration);
 
                     echo json_encode($result);
                 }

--- a/frontend/modules/poll/views/poll/options.php
+++ b/frontend/modules/poll/views/poll/options.php
@@ -12,10 +12,13 @@ use yii\helpers\Json;
 ?>
 <?php if ($poll->result_type == 2) {
     $result_type = 'column';
-} elseif ($poll->result_type == 1) {
-    $result_type = 'bar';
-} else {
+} elseif ($poll->result_type == 3) {
     $result_type = 'pie';
+} elseif ($poll->result_type == 4) {
+    // Новий тип відповідає лінійному графіку Highcharts із динамікою відсотків у часі.
+    $result_type = 'line';
+} else {
+    $result_type = 'bar';
 } ?>
 <?php if(!$poll->isShowResult()):?>
     <form method="post" action="<?= Url::toRoute(['/poll/poll/vote']); ?>" class="poll-option-form">
@@ -48,6 +51,7 @@ use yii\helpers\Json;
         'title' => (string)$poll->title,
         'series' => StringHelper::formatForBarAjax($chartData)['series'] ?? [],
         'pie' => StringHelper::formatForPieAjax($chartData),
+        'line' => $poll->getLineChartData(),
     ]);
     ?>
     <div

--- a/frontend/modules/poll/views/poll/view.php
+++ b/frontend/modules/poll/views/poll/view.php
@@ -120,20 +120,30 @@ JS
                         <div class="poll_view_chart_toggle">
                             <span class="chosen_graph_b animated_b">
                                 <span class="inner_chosen_graph">
-                                    <a href="javascript:void(0)" class="pie_chart" data-id="pie">
+                                    <?php // Активний перемикач синхронізуємо з result_type, зокрема для нового лінійного графіка. ?>
+                                    <a href="javascript:void(0)" class="pie_chart <?= ($poll->result_type == 3) ? 'active' : ''; ?>" data-id="pie">
                                         <span class="pie_chart_img"></span>
                                         <span class="vertical_chart_img"></span>
                                         <span class="horizontal_chart_img"></span>
+                                        <span class="line_chart_img"></span>
                                     </a>
-                                    <a href="javascript:void(0)" class="horizontal_b_chart active" data-id="bar">
+                                    <a href="javascript:void(0)" class="horizontal_b_chart <?= (!$poll->result_type || $poll->result_type == 1) ? 'active' : ''; ?>" data-id="bar">
                                         <span class="pie_chart_img"></span>
                                         <span class="vertical_chart_img"></span>
                                         <span class="horizontal_chart_img"></span>
+                                        <span class="line_chart_img"></span>
                                     </a>
-                                    <a href="javascript:void(0)" class="vertical_b_chart" data-id="column">
+                                    <a href="javascript:void(0)" class="vertical_b_chart <?= ($poll->result_type == 2) ? 'active' : ''; ?>" data-id="column">
                                         <span class="pie_chart_img"></span>
                                         <span class="vertical_chart_img"></span>
                                         <span class="horizontal_chart_img"></span>
+                                        <span class="line_chart_img"></span>
+                                    </a>
+                                    <a href="javascript:void(0)" class="line_chart <?= ($poll->result_type == 4) ? 'active' : ''; ?>" data-id="line">
+                                        <span class="pie_chart_img"></span>
+                                        <span class="vertical_chart_img"></span>
+                                        <span class="horizontal_chart_img"></span>
+                                        <span class="line_chart_img"></span>
                                     </a>
                                 </span>
                             </span>
@@ -469,8 +479,8 @@ jQuery(document).on('click', '.autocomplete-suggestion', function () {
 });
 */
 
-jQuery(document).on('click', '.pie_chart,.horizontal_b_chart,.vertical_b_chart', function () {
-    jQuery('#container$pollId').removeClass('pie').removeClass('bar').removeClass('column');
+jQuery(document).on('click', '.pie_chart,.horizontal_b_chart,.vertical_b_chart,.line_chart', function () {
+    jQuery('#container$pollId').removeClass('pie').removeClass('bar').removeClass('column').removeClass('line');
     jQuery('#container$pollId').addClass(jQuery(this).attr('data-id'));
     filterDataChart($pollId, $pollTitle);
 });

--- a/frontend/views/poll/options.php
+++ b/frontend/views/poll/options.php
@@ -6,10 +6,13 @@ use yii\helpers\Json;
 
 if ($poll->result_type == 2) {
     $result_type = 'column';
-} elseif ($poll->result_type == 1) {
-    $result_type = 'bar';
-} else {
+} elseif ($poll->result_type == 3) {
     $result_type = 'pie';
+} elseif ($poll->result_type == 4) {
+    // Лінійний тип показує накопичувальну динаміку голосування у відсотках.
+    $result_type = 'line';
+} else {
+    $result_type = 'bar';
 }
 
 ?>
@@ -44,6 +47,7 @@ if ($poll->result_type == 2) {
         'title' => (string)$poll->title,
         'series' => StringHelper::formatForBarAjax($chartData)['series'] ?? [],
         'pie' => StringHelper::formatForPieAjax($chartData),
+        'line' => $poll->getLineChartData(),
     ]);
     ?>
     <div

--- a/frontend/views/poll/view.php
+++ b/frontend/views/poll/view.php
@@ -66,20 +66,30 @@ if (!empty($poll->pollLanguage)) {
                         <div class="poll_view_chart_toggle">
                             <span class="chosen_graph_b animated_b">
                                 <span class="inner_chosen_graph">
-                                    <a href="javascript:void(0)" class="pie_chart" data-id="pie">
+                                    <?php // Додаємо четвертий перемикач для лінійного графіка та синхронізуємо active з result_type. ?>
+                                    <a href="javascript:void(0)" class="pie_chart <?php echo ($poll->result_type == 3) ? 'active' : ''; ?>" data-id="pie">
                                         <span class="pie_chart_img"></span>
                                         <span class="vertical_chart_img"></span>
                                         <span class="horizontal_chart_img"></span>
+                                        <span class="line_chart_img"></span>
                                     </a>
-                                    <a href="javascript:void(0)" class="horizontal_b_chart active" data-id="bar">
+                                    <a href="javascript:void(0)" class="horizontal_b_chart <?php echo (!$poll->result_type || $poll->result_type == 1) ? 'active' : ''; ?>" data-id="bar">
                                         <span class="pie_chart_img"></span>
                                         <span class="vertical_chart_img"></span>
                                         <span class="horizontal_chart_img"></span>
+                                        <span class="line_chart_img"></span>
                                     </a>
-                                    <a href="javascript:void(0)" class="vertical_b_chart" data-id="column">
+                                    <a href="javascript:void(0)" class="vertical_b_chart <?php echo ($poll->result_type == 2) ? 'active' : ''; ?>" data-id="column">
                                         <span class="pie_chart_img"></span>
                                         <span class="vertical_chart_img"></span>
                                         <span class="horizontal_chart_img"></span>
+                                        <span class="line_chart_img"></span>
+                                    </a>
+                                    <a href="javascript:void(0)" class="line_chart <?php echo ($poll->result_type == 4) ? 'active' : ''; ?>" data-id="line">
+                                        <span class="pie_chart_img"></span>
+                                        <span class="vertical_chart_img"></span>
+                                        <span class="horizontal_chart_img"></span>
+                                        <span class="line_chart_img"></span>
                                     </a>
                                 </span>
                             </span>
@@ -290,8 +300,8 @@ if (!empty($poll->pollLanguage)) {
     });
 */
 
-    jQuery(document).on('click','.pie_chart,.horizontal_b_chart,.vertical_b_chart',function(){
-        jQuery('#container<?php echo $poll->id; ?>').removeClass('pie').removeClass('bar').removeClass('column');
+    jQuery(document).on('click','.pie_chart,.horizontal_b_chart,.vertical_b_chart,.line_chart',function(){
+        jQuery('#container<?php echo $poll->id; ?>').removeClass('pie').removeClass('bar').removeClass('column').removeClass('line');
         jQuery('#container<?php echo $poll->id; ?>').addClass(jQuery(this).attr('data-id'));
         filterDataChart(<?php echo $poll->id;?>,'<?php echo $poll->title;?>');
     });

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -4265,3 +4265,44 @@ a.btn_read_next_var span {
     z-index: 1;
     white-space: nowrap;
 }
+/* Лінійний графік додано як четвертий тип, тому перемикач розкривається на чотири іконки. */
+.chosen_graph_b:hover {
+    height: 102px;
+}
+.vertical_chart_img,
+.horizontal_chart_img,
+.pie_chart_img,
+.line_chart_img {
+    position: absolute;
+    width: 24px;
+    height: 25px;
+    opacity: 0;
+}
+.line_chart_img {
+    background: linear-gradient(135deg, transparent 39%, #3ac469 40%, #3ac469 47%, transparent 48%),
+        linear-gradient(25deg, transparent 48%, #3ac469 49%, #3ac469 55%, transparent 56%);
+}
+.inner_chosen_graph .line_chart,
+.tabs_graphs .line_chart {
+    background-image: linear-gradient(135deg, transparent 39%, #99a3a1 40%, #99a3a1 47%, transparent 48%),
+        linear-gradient(25deg, transparent 48%, #99a3a1 49%, #99a3a1 55%, transparent 56%);
+    background-repeat: no-repeat;
+    background-position: center;
+}
+.inner_chosen_graph .line_chart:hover,
+.tabs_graphs .line_chart:hover {
+    background-color: #3ac469;
+    background-image: linear-gradient(135deg, transparent 39%, #fff 40%, #fff 47%, transparent 48%),
+        linear-gradient(25deg, transparent 48%, #fff 49%, #fff 55%, transparent 56%);
+}
+.inner_chosen_graph .line_chart.active,
+.tabs_graphs .active .line_chart,
+.tabs_graphs .active .line_chart:hover {
+    background-image: linear-gradient(135deg, transparent 39%, #3ac469 40%, #3ac469 47%, transparent 48%),
+        linear-gradient(25deg, transparent 48%, #3ac469 49%, #3ac469 55%, transparent 56%);
+}
+.inner_chosen_graph .line_chart.active:hover,
+.chosen_graph_b:hover .line_chart.active {
+    background-image: linear-gradient(135deg, transparent 39%, #fff 40%, #fff 47%, transparent 48%),
+        linear-gradient(25deg, transparent 48%, #fff 49%, #fff 55%, transparent 56%);
+}

--- a/frontend/web/js/custom.js
+++ b/frontend/web/js/custom.js
@@ -300,7 +300,7 @@ function arrayTotal(data)
     return dataSum;
 }
 
-function renderChart(category,id,text,series,pie){
+function renderChart(category,id,text,series,pie,line){
     function htmlDecode(value){
         return $('<div/>').html(value).text();
     }
@@ -310,10 +310,20 @@ function renderChart(category,id,text,series,pie){
     }
 
     for(var i in pie){
-        pie[i][0] = htmlDecode(pie[i][0]);
+        if (pie[i][0]) {
+            pie[i][0] = htmlDecode(pie[i][0]);
+        } else if (pie[i].name) {
+            pie[i].name = htmlDecode(pie[i].name);
+        }
     }
 
-    $('#'+id).removeClass('pie').removeClass('bar').removeClass('column');
+    if (line && line.series) {
+        for (var lineIndex in line.series) {
+            line.series[lineIndex].name = htmlDecode(line.series[lineIndex].name);
+        }
+    }
+
+    $('#'+id).removeClass('pie').removeClass('bar').removeClass('column').removeClass('line');
     $('#'+id).addClass(category);
     if(category == 'bar'){
         $('#'+id).highcharts({
@@ -413,6 +423,59 @@ function renderChart(category,id,text,series,pie){
             },
             series: series
         });
+    } else if(category == 'line'){
+        var lineConfig = line || {};
+        // Готуємо окрему конфігурацію для лінійного графіка Highcharts: одна лінія = один варіант відповіді.
+        $('#'+id).highcharts({
+            colors: highchartColors,
+            chart: {
+                type: 'line',
+                plotBackgroundColor: '#f4fbf4',
+                plotBorderWidth: null,
+                plotShadow: false
+            },
+            title: {
+                text: null
+            },
+            xAxis: {
+                categories: lineConfig.categories || [],
+                tickmarkPlacement: 'on',
+                title: {
+                    text: null
+                }
+            },
+            yAxis: {
+                min: 0,
+                max: 100,
+                title: {
+                    text: null
+                },
+                labels: {
+                    format: '{value}%'
+                }
+            },
+            tooltip: {
+                shared: true,
+                valueSuffix: '%'
+            },
+            plotOptions: {
+                line: {
+                    marker: {
+                        enabled: false
+                    },
+                    dataLabels: {
+                        enabled: false
+                    }
+                },
+                series: {
+                    lineWidth: 3
+                }
+            },
+            credits: {
+                enabled: false
+            },
+            series: lineConfig.series || []
+        });
     } else {
         $('#'+id).highcharts({
             colors: highchartColors,
@@ -473,11 +536,13 @@ function filterDataChart(id,title){
             }
 
             if($('#container'+id).hasClass('pie')){
-                renderChart('pie','container'+id,title,data.bar.series,data.pie);
+                renderChart('pie','container'+id,title,data.bar.series,data.pie,data.line);
             } else if($('#container'+id).hasClass('bar')){
-                renderChart('bar','container'+id,title,data.bar.series,data.pie);
+                renderChart('bar','container'+id,title,data.bar.series,data.pie,data.line);
+            } else if($('#container'+id).hasClass('line')){
+                renderChart('line','container'+id,title,data.bar.series,data.pie,data.line);
             } else {
-                renderChart('column','container'+id,title,data.bar.series,data.pie);
+                renderChart('column','container'+id,title,data.bar.series,data.pie,data.line);
             }
         }
     });

--- a/frontend/web/js/main.js
+++ b/frontend/web/js/main.js
@@ -95,12 +95,16 @@ function animationForZilla() {
                 $(this).css({
                     'background-image' : 'none'
                 });
+            } else if ($(this).hasClass('line_chart active')) {
+                // Для нового лінійного типу лишаємо CSS-іконку, бо окремого PNG немає.
+                elementBg = null;
+                elementChosen = $(this);
             }
         });
         $(".chosen_graph_b").bind("DOMSubtreeModified", function() {
             if(!$(this).hasClass('animated_b')) {
                 elementChosen.css({
-                    'background-image': 'url(../img/layout/'+elementBg+'_white.png)'
+                    'background-image': elementBg ? 'url(../img/layout/'+elementBg+'_white.png)' : ''
                 });
             } else {
                 elementChosen.css({

--- a/frontend/web/js/poll-chart-queue.js
+++ b/frontend/web/js/poll-chart-queue.js
@@ -25,7 +25,7 @@
                 continue;
             }
 
-            renderChart(item.category, item.id, item.title || '', item.series || [], item.pie || []);
+            renderChart(item.category, item.id, item.title || '', item.series || [], item.pie || [], item.line || {});
         }
     });
 })(jQuery);

--- a/frontend/web/js/poll-create-modal.js
+++ b/frontend/web/js/poll-create-modal.js
@@ -133,4 +133,14 @@ function refreshChart(popUpNum) {
     renderChart('bar', 'new_poll' + popUpNum + ' #horizontal_b_chart', title, series, pie);
     renderChart('column', 'new_poll' + popUpNum + ' #vertical_b_chart', title, series, pie);
     renderChart('pie', 'new_poll' + popUpNum + ' #pie_chart', title, series, pie);
+
+    // Прев'ю лінійного графіка імітує зміну відсотків у часі без збереження тестових голосів.
+    var line = {categories: ['День 1', 'День 2', 'День 3', 'День 4'], series: []};
+    for (var j = 0; j < series.length; ++j) {
+        line.series[j] = {
+            name: series[j].name,
+            data: [getRandomInt(), getRandomInt(), getRandomInt(), getRandomInt()]
+        };
+    }
+    renderChart('line', 'new_poll' + popUpNum + ' #line_chart', title, series, pie, line);
 }

--- a/frontend/widgets/views/create-poll-modal.php
+++ b/frontend/widgets/views/create-poll-modal.php
@@ -110,12 +110,15 @@ $model = $pollModel;
                             <li class="<?php if (!$model->result_type || $model->result_type == 1): ?>active<?php endif; ?>"><input id="type_1" type="radio" name="Poll[type]" value="1" <?php if (!$model->result_type || $model->result_type == 1): ?>checked<?php endif; ?> hidden><a href="#horizontal_b_chart" class="horizontal_b_chart" role="tab" data-toggle="tab"></a></li>
                             <li class="<?php if ($model->result_type == 2): ?>active<?php endif; ?>"><input id="type_2" type="radio" name="Poll[type]" value="2" <?php if ($model->result_type == 2): ?>checked<?php endif; ?> hidden><a href="#vertical_b_chart" class="vertical_b_chart" role="tab" data-toggle="tab"></a></li>
                             <li class="<?php if ($model->result_type == 3): ?>active<?php endif; ?>"><input id="type_3" type="radio" name="Poll[type]" value="3" <?php if ($model->result_type == 3): ?>checked<?php endif; ?> hidden><a href="#pie_chart" class="pie_chart" role="tab" data-toggle="tab"></a></li>
+                            <?php // Додаємо лінійний графік як четвертий тип результатів опитування. ?>
+                            <li class="<?php if ($model->result_type == 4): ?>active<?php endif; ?>"><input id="type_4" type="radio" name="Poll[type]" value="4" <?php if ($model->result_type == 4): ?>checked<?php endif; ?> hidden><a href="#line_chart" class="line_chart" role="tab" data-toggle="tab"></a></li>
                         </ul>
                     </div>
                     <div class="tab-content tab_visual">
                         <div id="horizontal_b_chart" class="tab-pane <?php if (!$model->result_type || $model->result_type == 1): ?>active<?php endif; ?>" style="width:500px; height:400px;"></div>
                         <div id="vertical_b_chart" class="tab-pane <?php if ($model->result_type == 2): ?>active<?php endif; ?>" style="width:500px; height:400px;"></div>
                         <div id="pie_chart" class="tab-pane <?php if ($model->result_type == 3): ?>active<?php endif; ?>" style="width:500px; height:400px;"></div>
+                        <div id="line_chart" class="tab-pane <?php if ($model->result_type == 4): ?>active<?php endif; ?>" style="width:500px; height:400px;"></div>
                     </div>
                 </div>
             </div>
@@ -326,8 +329,8 @@ $scriptPoll = '';
           filterDataChart({$poll->id},'{$poll->title}');
           });
 
-          $(document).on('click','.pie_chart,.horizontal_b_chart,.vertical_b_chart',function(){
-          $('#container{$poll->id}').removeClass('pie').removeClass('bar').removeClass('column');
+          $(document).on('click','.pie_chart,.horizontal_b_chart,.vertical_b_chart,.line_chart',function(){
+          $('#container{$poll->id}').removeClass('pie').removeClass('bar').removeClass('column').removeClass('line');
           $('#container{$poll->id}').addClass($(this).attr('data-id'));
           filterDataChart({$poll->id},'{$poll->title}');
           });


### PR DESCRIPTION
### Motivation
- Додати до сторінок опитувань ще один тип візуалізації — лінійний графік з динамікою часток варіантів у часі — реалізований через існуючу бібліотеку Highcharts, щоб відповідати очікуваному вигляду конкурентів і не вводити нову залежність.

### Description
- Додано серверну логіку `getLineChartData`, `appendLineChartRows` та `buildLineChartPercentSeries` у `Poll` для підрахунку накопичувальних відсотків по датах голосування і підтримки фільтрів (`sex`, `age`, `country`, `registration`).
- Повернення даних AJAX оновлено в `AjaxController::actionGetChartData` та відповідній дії контролера `PollController`, щоб включати ключ `line` з історією для рендеру. 
- Клієнтська логіка розширена: `renderChart` в `frontend/web/js/custom.js` додано підтримку категорії `line` (конфіг `categories` + `series`), `poll-chart-queue.js` та `poll-create-modal.js` оновлено для передачі/preview `line`-даних; фільтри AJAX тепер перемальовують і лінійний графік.
- Шаблони та UI оновлені: додано `result_type == 4` як тип лінійного графіка у `frontend/modules/poll/views/poll/options.php`, `frontend/modules/poll/views/poll/view.php`, модалки створення/редагування (`create-poll-modal.php`, `create-poll-step-one.php`) та у дубльованих шаблонах у `frontend/views`, а також стилі в `frontend/web/css/main.css` для нової іконки/перемикача.

### Testing
- Перевірено синтаксис PHP для змінених PHP-файлів командою `php -l` — всі файли пройшли перевірку успішно. (усі змінені PHP-файли)
- Перевірено синтаксис JS для змінених JS-файлів командою `node --check` — всі файли пройшли перевірку успішно. (`frontend/web/js/custom.js`, `frontend/web/js/main.js`, `frontend/web/js/poll-chart-queue.js`, `frontend/web/js/poll-create-modal.js`)
- Виконано `composer validate --no-check-publish` — валідація пройшла, але `composer.json` показав попередження про `unbound version constraints` (попередження, не помилка).
- Локального headless-браузера для скріншотів не знайдено, тому відображення в браузері перевірити вручну; JS/PHP синтаксис‑перевірки пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28d1f58ecc832fb57640dcc6dd9483)