### PR TITLE
Expose period-based vote tokens for polls and improve admin token list layout

### DIFF
--- a/backend/modules/poll/views/poll-static-text/update.php
+++ b/backend/modules/poll/views/poll-static-text/update.php
@@ -13,6 +13,23 @@ use yii\widgets\ActiveForm;
 $this->title = 'Статичний текст для опитувань: ' . $language->title;
 $this->params['breadcrumbs'][] = ['label' => 'Статичний текст для опитувань', 'url' => ['index']];
 $this->params['breadcrumbs'][] = $language->title;
+
+// Локальний CSS без втручання в інші сторінки адмінки.
+$this->registerCss(<<<CSS
+.poll-static-token-list {
+    column-count: 2;
+    column-gap: 32px;
+}
+.poll-static-token-list li {
+    break-inside: avoid;
+}
+@media (max-width: 767px) {
+    .poll-static-token-list {
+        column-count: 1;
+    }
+}
+CSS
+);
 ?>
 <div class="poll-static-text-update">
     <h1><?= Html::encode($this->title); ?></h1>
@@ -21,7 +38,8 @@ $this->params['breadcrumbs'][] = $language->title;
         Тут можна налаштувати статичний HTML-блок зі статистикою та мета-теги сторінок опитувань.
         Нижче наведено змінні, які можна використовувати у статичному тексті:
     </p>
-    <ul>
+    <ul class="poll-static-token-list">
+        <?php // Розбиваємо довгий список змінних на два стовпці, щоб адмінка лишалася зручною. ?>
         <?php foreach ($infoTokens as $token => $description): ?>
             <li><code><?= Html::encode($token); ?></code> — <?= Html::encode($description); ?></li>
         <?php endforeach; ?>
@@ -47,7 +65,8 @@ $this->params['breadcrumbs'][] = $language->title;
                 <p>
                     Доступні змінні для цих полів:
                 </p>
-                <ul>
+                <ul class="poll-static-token-list">
+                    <?php // Такий самий двоколонковий вигляд для змінних мета-тегів. ?>
                     <?php foreach ($metaTokens as $token => $description): ?>
                         <li><code><?= Html::encode($token); ?></code> — <?= Html::encode($description); ?></li>
                     <?php endforeach; ?>

--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -1553,6 +1553,10 @@ class Poll extends ActiveRecord
             '@date_month' => 'Місяць створення опитування (MM).',
             '@date_year' => 'Рік створення опитування (YYYY).',
             '@votes_total' => 'Загальна кількість голосів.',
+            '@votes_last_month' => 'Кількість голосів за останній місяць.',
+            '@votes_this_month' => 'Кількість голосів за цей місяць.',
+            '@votes_this_year' => 'Кількість голосів за цей рік.',
+            '@votes_previous_year' => 'Кількість голосів за минулий рік.',
             '@comments' => 'Кількість коментарів.',
             '@options_count' => 'Кількість варіантів відповіді.',
             '@options_titles' => 'Перелік варіантів відповіді через кому.',
@@ -1580,6 +1584,10 @@ class Poll extends ActiveRecord
             '@author_name' => 'Імʼя автора опитування.',
             '@author_id' => 'ID автора опитування.',
             '@votes_total' => 'Загальна кількість голосів.',
+            '@votes_last_month' => 'Кількість голосів за останній місяць.',
+            '@votes_this_month' => 'Кількість голосів за цей місяць.',
+            '@votes_this_year' => 'Кількість голосів за цей рік.',
+            '@votes_previous_year' => 'Кількість голосів за минулий рік.',
             '@votes_registered' => 'Кількість голосів від зареєстрованих користувачів.',
             '@votes_guest' => 'Кількість голосів від гостей.',
             '@comments' => 'Кількість коментарів.',
@@ -1669,6 +1677,9 @@ class Poll extends ActiveRecord
 
         $commentsCount = count($this->pollComments);
 
+        // Рахуємо часові зрізи голосів окремо, щоб адміністратор міг виводити динаміку в статичному блоці.
+        $periodVotes = $this->getStaticPeriodVotes();
+
         // Формуємо HTML-список варіантів з голосами, щоб можна було вставляти у шаблон.
         $optionsListHtml = '';
         if (!empty($stats)) {
@@ -1723,6 +1734,10 @@ class Poll extends ActiveRecord
             'tagsPlain' => $tagsPlain,
             'tagsCount' => $tagsCount,
             'votesTotal' => (int) $this->countPollOptionsVoters,
+            'votesLastMonth' => $periodVotes['lastMonth'],
+            'votesThisMonth' => $periodVotes['thisMonth'],
+            'votesThisYear' => $periodVotes['thisYear'],
+            'votesPreviousYear' => $periodVotes['previousYear'],
             'optionsCount' => count($stats),
             'date' => $dateParts['date'],
             'dateIso' => $dateParts['dateIso'],
@@ -1736,6 +1751,52 @@ class Poll extends ActiveRecord
             'languageId' => (string) $this->poll_language_id,
             'authorName' => $authorName,
             'authorId' => (string) $this->user_id,
+        ];
+    }
+
+
+    /**
+     * Рахує голоси опитування у потрібному часовому проміжку для статичних змінних.
+     */
+    private function countStaticVotesBetween(string $from, ?string $to = null): int
+    {
+        // Зареєстровані й гостьові голоси лежать у різних таблицях, тому об'єднуємо їх без зміни існуючої логіки голосування.
+        $registeredQuery = (new Query())
+            ->from('{{%option_vote}} ov')
+            ->innerJoin('{{%poll_option}} po', 'po.id = ov.option_id')
+            ->where(['po.poll_id' => (int) $this->id])
+            ->andWhere(['>=', 'ov.date_add', $from]);
+
+        $guestQuery = (new Query())
+            ->from('{{%option_guest_vote}} ogv')
+            ->where(['ogv.poll_id' => (int) $this->id])
+            ->andWhere(['>=', 'ogv.date_add', $from]);
+
+        if ($to !== null) {
+            $registeredQuery->andWhere(['<', 'ov.date_add', $to]);
+            $guestQuery->andWhere(['<', 'ogv.date_add', $to]);
+        }
+
+        return (int) $registeredQuery->count() + (int) $guestQuery->count();
+    }
+
+    /**
+     * Готує календарні та rolling-періоди для змінних статичного тексту опитування.
+     */
+    private function getStaticPeriodVotes(): array
+    {
+        $thisMonthStart = date('Y-m-01 00:00:00');
+        $nextMonthStart = date('Y-m-01 00:00:00', strtotime('+1 month'));
+        $thisYearStart = date('Y-01-01 00:00:00');
+        $nextYearStart = date('Y-01-01 00:00:00', strtotime('+1 year'));
+        $previousYearStart = date('Y-01-01 00:00:00', strtotime('-1 year'));
+
+        return [
+            'lastMonth' => $this->countStaticVotesBetween(date('Y-m-d H:i:s', strtotime('-1 month'))),
+            // Цей місяць рахуємо як календарний період від першого дня поточного місяця.
+            'thisMonth' => $this->countStaticVotesBetween($thisMonthStart, $nextMonthStart),
+            'thisYear' => $this->countStaticVotesBetween($thisYearStart, $nextYearStart),
+            'previousYear' => $this->countStaticVotesBetween($previousYearStart, $thisYearStart),
         ];
     }
 
@@ -1777,6 +1838,8 @@ class Poll extends ActiveRecord
         }, $this->pollOptions);
         $authorName = $this->user_id ? User::getUserName($this->user_id) : '';
         $commentsCount = count($this->pollComments);
+        // Для мета-тегів використовуємо ті самі межі періодів, що й у статичному HTML-блоці.
+        $periodVotes = $this->getStaticPeriodVotes();
 
         return [
             '@title' => $this->title,
@@ -1797,6 +1860,10 @@ class Poll extends ActiveRecord
             '@date_month' => $dateMonth,
             '@date_year' => $dateYear,
             '@votes_total' => (string) $this->countPollOptionsVoters,
+            '@votes_last_month' => (string) $periodVotes['lastMonth'],
+            '@votes_this_month' => (string) $periodVotes['thisMonth'],
+            '@votes_this_year' => (string) $periodVotes['thisYear'],
+            '@votes_previous_year' => (string) $periodVotes['previousYear'],
             '@comments' => (string) $commentsCount,
             '@options_count' => (string) count($this->pollOptions),
             '@options_titles' => implode(', ', $optionsTitles),
@@ -1828,6 +1895,10 @@ class Poll extends ActiveRecord
             '@author_name' => $data['authorName'],
             '@author_id' => $data['authorId'],
             '@votes_total' => (string) $data['votesTotal'],
+            '@votes_last_month' => (string) $data['votesLastMonth'],
+            '@votes_this_month' => (string) $data['votesThisMonth'],
+            '@votes_this_year' => (string) $data['votesThisYear'],
+            '@votes_previous_year' => (string) $data['votesPreviousYear'],
             '@votes_registered' => (string) $data['registeredVotes'],
             '@votes_guest' => (string) $data['guestVotes'],
             '@comments' => (string) $data['commentsCount'],


### PR DESCRIPTION
### Motivation
- Provide administrators with time-sliced vote statistics to insert into static poll HTML and meta templates. 
- Keep the admin UI usable when token lists grow by improving token list layout. 

### Description
- Added new static tokens for period-based vote counts: `@votes_last_month`, `@votes_this_month`, `@votes_this_year`, and `@votes_previous_year` in `Poll::getStaticMetaTokens()` and `Poll::getStaticInfoTokens()`. 
- Implemented vote counting helpers `countStaticVotesBetween()` and `getStaticPeriodVotes()` to compute calendar and rolling periods by aggregating registered and guest votes. 
- Wire the computed period values into `getStaticInfoBlock()` return data and into meta/info replacement arrays (`getStaticMetaReplacements()` and `getStaticInfoReplacements()`). 
- Improved admin view `backend/modules/poll/views/poll-static-text/update.php` by registering scoped CSS and rendering token lists with a responsive two-column layout (`.poll-static-token-list`) and minor template comments. 

### Testing
- Ran the existing automated test suite with `phpunit`, and the test run completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3706e1d1a4832f9c5eaa69bd505209)