### PR TITLE
Підтримка одного зображення для опитування

### DIFF
--- a/backend/modules/poll/controllers/PollController.php
+++ b/backend/modules/poll/controllers/PollController.php
@@ -2,11 +2,13 @@
 
 namespace backend\modules\poll\controllers;
 
+use Yii;
 use common\models\PollFaq;
 use common\models\Poll;
 use common\models\search\PollSearch;
 use yii\web\Controller;
 use yii\web\NotFoundHttpException;
+use yii\web\UploadedFile;
 use yii\filters\VerbFilter;
 
 /**
@@ -74,11 +76,16 @@ class PollController extends Controller
         $model = new Poll();
 
         if ($this->request->isPost) {
-            if ($model->load($this->request->post()) && $model->save()) {
-                // Після збереження синхронізуємо теги, щоб одразу створити зв'язки.
-                $model->syncTags($model->tagNames);
-                $this->savePollFaq($model);
-                return $this->redirect(['view', 'id' => $model->id]);
+            if ($model->load($this->request->post())) {
+                // Отримуємо файл після load(), щоб валідація моделі врахувала завантажене зображення.
+                $model->imageFile = UploadedFile::getInstance($model, 'imageFile');
+                // Спершу валідуємо всі поля, потім переносимо файл і зберігаємо URL разом з опитуванням.
+                if ($model->validate() && $model->uploadImage() && $model->save(false)) {
+                    // Після збереження синхронізуємо теги, щоб одразу створити зв'язки.
+                    $model->syncTags($model->tagNames);
+                    $this->savePollFaq($model);
+                    return $this->redirect(['view', 'id' => $model->id]);
+                }
             }
         } else {
             $model->loadDefaultValues();
@@ -100,11 +107,16 @@ class PollController extends Controller
     {
         $model = $this->findModel($id);
 
-        if ($this->request->isPost && $model->load($this->request->post()) && $model->save()) {
-            // Оновлюємо теги після збереження, щоб відобразити всі зміни зі сторінки редагування.
-            $model->syncTags($model->tagNames);
-            $this->savePollFaq($model);
-            return $this->redirect(['view', 'id' => $model->id]);
+        if ($this->request->isPost && $model->load($this->request->post())) {
+            // Отримуємо новий файл, якщо редактор замінює зображення опитування.
+            $model->imageFile = UploadedFile::getInstance($model, 'imageFile');
+            // uploadImage() не змінює image_url, якщо файл не було вибрано, тож наявне зображення зберігається.
+            if ($model->validate() && $model->uploadImage() && $model->save(false)) {
+                // Оновлюємо теги після збереження, щоб відобразити всі зміни зі сторінки редагування.
+                $model->syncTags($model->tagNames);
+                $this->savePollFaq($model);
+                return $this->redirect(['view', 'id' => $model->id]);
+            }
         }
 
         return $this->render('update', [

--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -16,7 +16,7 @@ use common\models\PollFaq;
 
 <div class="poll-form">
 
-    <?php $form = ActiveForm::begin(); ?>
+    <?php $form = ActiveForm::begin(['options' => ['enctype' => 'multipart/form-data']]); ?>
 
     <?= $form->field($model, 'title')->textInput(['maxlength' => true]) ?>
     <div class="panel panel-default">
@@ -32,6 +32,24 @@ use common\models\PollFaq;
         </div>
     </div>
     <?= $form->field($model, 'describe')->widget(ashch\tinymce\TinyMce::class); ?>
+
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Зображення опитування</strong></div>
+        <div class="panel-body">
+            <?php // Завантажуємо тільки один файл; поточне зображення лишається, якщо новий файл не вибрано. ?>
+            <?= $form->field($model, 'imageFile')->fileInput(['accept' => 'image/jpeg,image/png']) ?>
+            <?= $form->field($model, 'image_alt')->textInput(['maxlength' => true]) ?>
+            <?php if (!empty($model->image_url)): ?>
+                <div class="poll-current-image">
+                    <?= Html::img($model->image_url, [
+                        'alt' => $model->image_alt ?: $model->title,
+                        'class' => 'img-responsive',
+                        'style' => 'max-width: 320px;',
+                    ]); ?>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
     <?php
     // Завантажуємо індивідуальні FAQ для цього опитування (або показуємо 2 порожні рядки для нового).
     $pollFaqItems = $model->isNewRecord ? [] : PollFaq::find()->where(['poll_id' => $model->id])->orderBy(['position' => SORT_ASC, 'id' => SORT_ASC])->all();

--- a/common/models/Poll.php
+++ b/common/models/Poll.php
@@ -6,8 +6,11 @@ use Yii;
 use common\components\ActiveRecord;
 use common\helpers\StringHelper;
 use yii\bootstrap\Html;
+use yii\helpers\FileHelper;
+use yii\helpers\Inflector;
 use yii\db\Expression;
 use yii\db\Query;
+use yii\web\UploadedFile;
 
 /**
  * This is the model class for table "{{%poll}}".
@@ -18,6 +21,8 @@ use yii\db\Query;
  * @property string|null $meta_h1 Meta H1
  * @property string|null $meta_title Meta title
  * @property string|null $meta_description Meta description
+ * @property string|null $image_url Image URL
+ * @property string|null $image_alt Image alt
  * @property int $user_id User
  * @property int $rating Rating
  * @property int $status Status
@@ -70,6 +75,10 @@ class Poll extends ActiveRecord
     const TIME_TO_EDIT = 5;
     public $editable = false;
 
+    /**
+     * @var UploadedFile|null Тимчасове зображення з форми адмінки; у БД зберігаємо тільки URL.
+     */
+    public $imageFile;
 
     public $showResultOnMainPage = NULL;
 
@@ -115,12 +124,22 @@ class Poll extends ActiveRecord
         return [
             [['title', 'user_id', 'status'], 'required'],
             [['describe', 'meta_description'], 'string'],
+            [['image_url'], 'string', 'max' => 1024],
+            [['image_alt'], 'string', 'max' => 255],
+            [
+                ['imageFile'],
+                'image',
+                'extensions' => ['jpg', 'jpeg', 'png'],
+                'mimeTypes' => ['image/jpeg', 'image/png'],
+                'maxSize' => 5 * 1024 * 1024,
+                'skipOnEmpty' => true,
+            ],
             [['user_id', 'rating', 'status', 'views', 'result_type', 'poll_language_id', 'show_for_all_languages', 'poll_sex', 'poll_country_id', 'poll_region_id', 'poll_city_id', 'poll_min_age', 'poll_max_age', 'votes_count_close', 'show_on_slider', 'created_by', 'updated_by', 'created_at', 'updated_at'], 'integer'],
             [['date_add', 'date_update'], 'safe'],
             // Дозволяємо масове присвоєння тегів як масиву назв.
             [['tagNames'], 'safe'],
             // Дозволяємо редагувати індивідуальні мета-поля опитування.
-            [['meta_h1', 'meta_title', 'meta_description'], 'default', 'value' => null],
+            [['meta_h1', 'meta_title', 'meta_description', 'image_url', 'image_alt'], 'default', 'value' => null],
             [['title', 'meta_h1', 'meta_title'], 'string', 'max' => 255],
             [['poll_language_id'], 'exist', 'skipOnError' => true, 'targetClass' => Language::class, 'targetAttribute' => ['poll_language_id' => 'id']],
         ];
@@ -138,6 +157,9 @@ class Poll extends ActiveRecord
             'meta_h1' => 'Meta H1',
             'meta_title' => 'Meta title',
             'meta_description' => 'Meta description',
+            'image_url' => 'Зображення (URL)',
+            'image_alt' => 'Alt-текст зображення',
+            'imageFile' => 'Зображення опитування',
             'user_id' => Yii::t('app', 'User'),
             'author.name' => Yii::t('app', 'Author'),
             'rating' => Yii::t('app', 'Rating'),
@@ -163,6 +185,57 @@ class Poll extends ActiveRecord
             'updated_at' => Yii::t('app', 'Updated at:'),
             'tagNames' => Yii::t('app', 'Tags'),
         ];
+    }
+
+
+    /**
+     * Зберігає завантажене зображення у публічну папку фронтенда й оновлює image_url.
+     */
+    public function uploadImage(): bool
+    {
+        if (!$this->imageFile instanceof UploadedFile) {
+            return true;
+        }
+
+        $directory = $this->getImagesDirectory();
+        if (!FileHelper::createDirectory($directory)) {
+            $this->addError('imageFile', 'Не вдалося створити папку для зображень опитувань.');
+            return false;
+        }
+
+        $extension = strtolower($this->imageFile->extension);
+        $baseName = pathinfo($this->imageFile->baseName, PATHINFO_FILENAME);
+        $safeBaseName = Inflector::slug($baseName) ?: 'poll-image';
+        // Додаємо випадковий суфікс, щоб новий файл не перезаписав наявні зображення опитувань.
+        $fileName = $safeBaseName . '-' . Yii::$app->security->generateRandomString(10) . '.' . $extension;
+        $filePath = $directory . DIRECTORY_SEPARATOR . $fileName;
+
+        // Фізично переносимо файл із тимчасової папки PHP у публічну папку фронтенда.
+        if (!$this->imageFile->saveAs($filePath)) {
+            $this->addError('imageFile', 'Не вдалося зберегти завантажене зображення.');
+            return false;
+        }
+
+        // У БД зберігаємо тільки URL, щоб не прив’язувати записи до абсолютного шляху сервера.
+        $this->image_url = $this->getImagesUrlPrefix() . $fileName;
+
+        return true;
+    }
+
+    /**
+     * Папка всередині frontend/web доступна за прямим URL /uploads/polls/*.
+     */
+    public function getImagesDirectory(): string
+    {
+        return Yii::getAlias('@frontend/web/uploads/polls');
+    }
+
+    /**
+     * URL-префікс для зображень опитувань на фронтенді.
+     */
+    public function getImagesUrlPrefix(): string
+    {
+        return '/uploads/polls/';
     }
 
     /**

--- a/console/migrations/m20260625_120000_add_image_fields_to_poll_table.php
+++ b/console/migrations/m20260625_120000_add_image_fields_to_poll_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Додає одне зображення до опитування: URL файлу та альтернативний текст.
+ */
+class m20260625_120000_add_image_fields_to_poll_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%poll}}', 'image_url', $this->string(1024)->null()->after('meta_description'));
+        $this->addColumn('{{%poll}}', 'image_alt', $this->string(255)->null()->after('image_url'));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('{{%poll}}', 'image_alt');
+        $this->dropColumn('{{%poll}}', 'image_url');
+    }
+}

--- a/frontend/modules/poll/views/poll/view.php
+++ b/frontend/modules/poll/views/poll/view.php
@@ -79,10 +79,18 @@ JS
                                 <?php if (!empty($pageHeading)): ?>
                                     <?php // Переносимо itemprop="headline" безпосередньо на h1. ?>
                                     <h1 itemprop="headline"><?= $pageHeading; ?></h1>
+                                    <?php if (!empty($poll->image_url)): ?>
+                                        <?php // Alt береться з поля опитування, а за відсутності безпечно підставляємо назву. ?>
+                                        <?= Html::img($poll->image_url, ['alt' => $poll->image_alt ?: $poll->title, 'class' => 'poll-view-image', 'itemprop' => 'image']); ?>
+                                    <?php endif; ?>
                                 <?php else: ?>
                                     <?php // Додаємо префікс "Poll:" до заголовка опитування. ?>
                                     <?php // Переносимо itemprop="headline" безпосередньо на h1. ?>
                                     <h1 itemprop="headline"><?= Yii::t('poll', 'Опитування: {title}', ['title' => $poll->title]); ?></h1>
+                                    <?php if (!empty($poll->image_url)): ?>
+                                        <?php // Alt береться з поля опитування, а за відсутності безпечно підставляємо назву. ?>
+                                        <?= Html::img($poll->image_url, ['alt' => $poll->image_alt ?: $poll->title, 'class' => 'poll-view-image', 'itemprop' => 'image']); ?>
+                                    <?php endif; ?>
                                 <?php endif; ?>
                                 <span class="right_block_share_icon poll_view_share">
                                    <?php // Переміщаємо кнопку поширення ближче до заголовка для кращої читабельності. ?>

--- a/frontend/views/poll/view.php
+++ b/frontend/views/poll/view.php
@@ -1,6 +1,7 @@
 <?php
 
 use yii\helpers\Url;
+use yii\helpers\Html;
 
 /* @var $this yii\web\View */
 /* @var $poll \common\models\Poll */
@@ -33,6 +34,10 @@ if (!empty($poll->pollLanguage)) {
                             <div class="title_poll poll_view_title_row">
                                 <?php // Додаємо префікс "Poll:" до заголовка опитування. ?>
                                 <h1><?php echo Yii::t('poll', 'Опитування: {title}', ['title' => $poll->title]); ?></h1>
+                                <?php if (!empty($poll->image_url)): ?>
+                                    <?php // Alt береться з поля опитування, а за відсутності безпечно підставляємо назву. ?>
+                                    <?php echo Html::img($poll->image_url, ['alt' => $poll->image_alt ?: $poll->title, 'class' => 'poll-view-image']); ?>
+                                <?php endif; ?>
                                 <span class="right_block_share_icon poll_view_share">
                                     <?php // Переміщаємо кнопку поширення ближче до заголовка для органічного вигляду. ?>
                                     <?php $this->renderPartial('//site/polls/_shareSocial', array('poll' => $poll)); ?>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -4076,3 +4076,13 @@ a.btn_read_next_var span {
 .animated_b.chosen_graph_b:hover .inner_chosen_graph .line_chart.active {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='25' viewBox='0 0 24 25'%3E%3Cpath d='M4 20.5h16M4 20.5V4.5' fill='none' stroke='%23ffffff' stroke-width='2' stroke-linecap='round'/%3E%3Cpolyline points='5,17 10,12 14,14 20,7' fill='none' stroke='%23ffffff' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
+
+
+/* Зображення опитування розміщуємо під заголовком, не змінюючи блоки графіків. */
+.poll-view-image {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 12px 0 16px;
+    border-radius: 4px;
+}


### PR DESCRIPTION
### Motivation
- Додати можливість прикріпити одне зображення до опитування та зберігати в БД лише публічний `image_url` і супровідний `image_alt` для доступного виводу на фронтенді.

### Description
- Додано міграцію `console/migrations/m20260625_120000_add_image_fields_to_poll_table.php` яка створює колонки `image_url` (`string(1024)->null()`) і `image_alt` (`string(255)->null()`).
- Оновлено модель `common/models/Poll.php`: додано PHPDoc-властивості `image_url`, `image_alt`, публічну властивість `imageFile`, імпорти `UploadedFile`, `FileHelper`, `Inflector`, правила валідації для `image_url`, `image_alt` і `imageFile`, українські `attributeLabels`, метод `uploadImage()` з коментарями українською, а також `getImagesDirectory()` і `getImagesUrlPrefix()`.
- Оновлено backend: у форму створення/редагування `backend/modules/poll/views/poll/_form.php` додано `enctype => multipart/form-data`, поле завантаження `imageFile`, поле `image_alt` і прев’ю поточного зображення; у контролері `backend/modules/poll/controllers/PollController.php` після `load()` отримується файл через `UploadedFile::getInstance($model, 'imageFile')`, виконується `validate()` + `uploadImage()` і збереження через `save(false)` без порушення логіки синхронізації тегів і FAQ.
- Оновлено фронтенд-в’ю: у `frontend/modules/poll/views/poll/view.php` і `frontend/views/poll/view.php` додається вивід `<img>` одразу після `<h1>` лише якщо `image_url` непорожній з `alt` = `image_alt` або fallback на назву опитування; додано базовий CSS-клас `.poll-view-image` у `frontend/web/css/main.css` для коректного відображення без зміни верстки графіків.

### Testing
- Прогнано синтаксичні перевірки `php -l` для `common/models/Poll.php`, `backend/modules/poll/controllers/PollController.php`, `backend/modules/poll/views/poll/_form.php`, `frontend/modules/poll/views/poll/view.php`, `frontend/views/poll/view.php` та `console/migrations/m20260625_120000_add_image_fields_to_poll_table.php` — всі пройшли успішно.
- Перевірено `git diff --check` — без помітних проблем у змінах.
- Спроба виконати `php yii help migrate` у середовищі не пройшла через відсутній локальний конфіг `common/config/main-local.php`, тому сама міграція не була застосована в цьому середовищі (міграційний файл доданий до репозиторію).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d8cc530a4832f9ec7e1932aa76524)