### PR TITLE
Додає статистику коментарів на адмінський дашборд

### DIFF
--- a/backend/modules/poll/controllers/DefaultController.php
+++ b/backend/modules/poll/controllers/DefaultController.php
@@ -67,6 +67,25 @@ SQL1;
             $data['monthly_totals']['previous'] = (int)$dataVotes[$previousMonthIndex]['user_votes']
                 + (int)$dataVotes[$previousMonthIndex]['guest_votes'];
         }
+
+        // Рахуємо коментарі окремо від голосів, щоб не змінювати існуючу SQL-логіку діаграми.
+        $commentPeriodsQuery = <<<SQL2
+SELECT
+    SUM(CASE WHEN `date_add` >= DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01') THEN 1 ELSE 0 END) AS current_comments,
+    SUM(CASE
+        WHEN `date_add` >= DATE_FORMAT(DATE_ADD(CURRENT_DATE(), INTERVAL -1 MONTH), '%Y-%m-01')
+            AND `date_add` < DATE_FORMAT(CURRENT_DATE(), '%Y-%m-01')
+        THEN 1 ELSE 0
+    END) AS previous_comments
+FROM `poll_comment`
+WHERE `date_add` >= DATE_FORMAT(DATE_ADD(CURRENT_DATE(), INTERVAL -1 MONTH), '%Y-%m-01')
+SQL2;
+        $commentPeriods = Yii::$app->db->createCommand($commentPeriodsQuery)->queryOne();
+        $data['comments_monthly_totals'] = [
+            'current' => (int)($commentPeriods['current_comments'] ?? 0),
+            'previous' => (int)($commentPeriods['previous_comments'] ?? 0),
+        ];
+
         return $this->render('index', ['data' => $data]);
     }
 

--- a/backend/modules/poll/views/default/index.php
+++ b/backend/modules/poll/views/default/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use dosamigos\chartjs\ChartJs;
+use yii\helpers\Html;
 use yii\web\JsExpression;
 
 $this->title = Yii::t('app', 'Dashboard');
@@ -37,6 +38,39 @@ $this->title = Yii::t('app', 'Dashboard');
                         </div>
                         <div style="font-size: 14px; color: #6c757d; margin-top: 6px;">
                             <?= Yii::t('app', 'голосів в опитуваннях') ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- Другий рядок показує динаміку коментарів з клікабельними числами для швидкого переходу до модерації. -->
+        <div class="row">
+            <div class="col-md-6">
+                <div class="box box-warning">
+                    <div class="box-body text-center" style="padding: 22px 16px;">
+                        <div style="font-size: 16px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #f39c12;">
+                            <?= Yii::t('app', 'КОМЕНТАРІ ЦЬОГО МІСЯЦЯ') ?>
+                        </div>
+                        <div style="font-size: 48px; line-height: 1.1; font-weight: 800; margin-top: 8px;">
+                            <?= Html::a(number_format((int)($data['comments_monthly_totals']['current'] ?? 0), 0, '.', ' '), ['/poll/poll-comment/index'], ['style' => 'color: #1f2d3d; text-decoration: underline;']) ?>
+                        </div>
+                        <div style="font-size: 14px; color: #6c757d; margin-top: 6px;">
+                            <?= Yii::t('app', 'коментарів в опитуваннях') ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="box box-warning">
+                    <div class="box-body text-center" style="padding: 22px 16px;">
+                        <div style="font-size: 16px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #f39c12;">
+                            <?= Yii::t('app', 'КОМЕНТАРІ МИНУЛОГО МІСЯЦЯ') ?>
+                        </div>
+                        <div style="font-size: 48px; line-height: 1.1; font-weight: 800; margin-top: 8px;">
+                            <?= Html::a(number_format((int)($data['comments_monthly_totals']['previous'] ?? 0), 0, '.', ' '), ['/poll/poll-comment/index'], ['style' => 'color: #1f2d3d; text-decoration: underline;']) ?>
+                        </div>
+                        <div style="font-size: 14px; color: #6c757d; margin-top: 6px;">
+                            <?= Yii::t('app', 'коментарів в опитуваннях') ?>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Адмінка показує лише кількість голосів за поточний і минулий місяць; потрібно також показати кількість коментарів для швидкого переходу до модерації.

### Description
- Додано SQL-запит у `backend/modules/poll/controllers/DefaultController.php` для підрахунку коментарів за поточний та попередній календарні місяці та збереження їх у `data['comments_monthly_totals']`.
- Додано відображення окремого рядка у `backend/modules/poll/views/default/index.php` із двома великими блоками для `коментарі цього місяця` та `коментарі минулого місяця` з клікабельними числами через `Html::a()` що ведуть на сторінку коментарів `['/poll/poll-comment/index']`.
- Додано `use yii\helpers\Html;` у в'юшці та коментарі в коді, щоб не змінювати існуючу логіку графіка голосів і залишити підрахунок коментарів ізольованим.

### Testing
- Виконано синтаксичну перевірку PHP для змінених файлів: `php -l backend/modules/poll/controllers/DefaultController.php` — без помилок.
- Виконано синтаксичну перевірку PHP для в'юшки: `php -l backend/modules/poll/views/default/index.php` — без помилок.
- Перевірено зміни стилю/помилки за допомогою `git diff --check` — проблем не виявлено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53c420979c832fa65b44c96f362c4a)