### PR TITLE
Адаптивне багатоколонкове компонування футера

### DIFF
--- a/frontend/views/layouts/main/footer.php
+++ b/frontend/views/layouts/main/footer.php
@@ -11,23 +11,31 @@ use yii\helpers\Html;
 $prefix =  ('https://online-statistics.org' !=  Yii::$app->request->hostinfo) ? '' : 'https://en.online-statistics.org';
 // Отримуємо набір посилань для поточної мови + глобальні посилання для всіх мов.
 $footerLinks = FooterLink::getForLanguage((string) Yii::$app->language);
+// Розподіляємо довгий список максимум на чотири рівномірні стовпці.
+$footerColumnCount = min(4, max(1, (int) ceil(count($footerLinks) / 4)));
+$footerLinkColumns = array_chunk($footerLinks, max(1, (int) ceil(count($footerLinks) / $footerColumnCount)));
+$footerColumnClass = 'col-xs-12 col-sm-' . (12 / $footerColumnCount);
 ?>
 <!-- Footer
 ================================================== -->
 <footer class="footer">
     <div class="container">
+        <nav class="row foot_links" aria-label="Footer navigation">
+            <?php foreach ($footerLinkColumns as $footerLinkColumn): ?>
+                <ul class="<?= $footerColumnClass; ?> list-unstyled">
+                    <?php foreach ($footerLinkColumn as $footerLink): ?>
+                        <?php
+                        // Не нашкодь: виводимо дані безпечно, а URL приводимо до валідного виду.
+                        $url = preg_match('/^https?:\/\//i', (string) $footerLink->url)
+                            ? $footerLink->url
+                            : Url::to($footerLink->url);
+                        ?>
+                        <li><a href="<?= Html::encode($url); ?>"><?= Html::encode($footerLink->anchor); ?></a></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endforeach; ?>
+        </nav>
         <div class="row">
-            <span class="foot_links">
-                <?php foreach ($footerLinks as $footerLink): ?>
-                    <?php
-                    // Не нашкодь: виводимо дані безпечно, а URL приводимо до валідного виду.
-                    $url = preg_match('/^https?:\/\//i', (string) $footerLink->url)
-                        ? $footerLink->url
-                        : Url::to($footerLink->url);
-                    ?>
-                    <a href="<?= Html::encode($url); ?>"><?= Html::encode($footerLink->anchor); ?></a>
-                <?php endforeach; ?>
-            </span>
             <span class="copyright">All Rights Reserved | <?= date('Y'); ?></span>
         </div>
 <?php /*                 * / ?>

--- a/frontend/views/layouts/main/footer.php
+++ b/frontend/views/layouts/main/footer.php
@@ -13,7 +13,18 @@ $prefix =  ('https://online-statistics.org' !=  Yii::$app->request->hostinfo) ? 
 $footerLinks = FooterLink::getForLanguage((string) Yii::$app->language);
 // Розподіляємо довгий список максимум на чотири рівномірні стовпці.
 $footerColumnCount = min(4, max(1, (int) ceil(count($footerLinks) / 4)));
-$footerLinkColumns = array_chunk($footerLinks, max(1, (int) ceil(count($footerLinks) / $footerColumnCount)));
+$footerLinkColumns = [];
+$footerLinkOffset = 0;
+$footerLinksPerColumn = intdiv(count($footerLinks), $footerColumnCount);
+$footerColumnsWithExtraLink = count($footerLinks) % $footerColumnCount;
+for ($columnIndex = 0; $columnIndex < $footerColumnCount; $columnIndex++) {
+    // Перші стовпці отримують по одному залишковому посиланню, тому різниця не перевищує одного пункту.
+    $footerColumnSize = $footerLinksPerColumn + ($columnIndex < $footerColumnsWithExtraLink ? 1 : 0);
+    if ($footerColumnSize > 0) {
+        $footerLinkColumns[] = array_slice($footerLinks, $footerLinkOffset, $footerColumnSize);
+        $footerLinkOffset += $footerColumnSize;
+    }
+}
 $footerColumnClass = 'col-xs-12 col-sm-' . (12 / $footerColumnCount);
 ?>
 <!-- Footer

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -1520,27 +1520,45 @@ span.item_list_poll:hover {
     height: 19px;
 }
 .footer {
-    height: 80px;
+    /* Автоматична висота дає футеру безпечно зростати разом із кількістю сторінок. */
+    min-height: 80px;
     background: #dce6e4;
     border-top: 3px solid #c4cfcd;
     padding-top: 20px;
+    padding-bottom: 15px;
 }
 .copyright {
     float: right;
     color: #0A3D20;
     padding-right: 3%;
 }
+.foot_links ul {
+    /* Використовуємо наявну Bootstrap-сітку, додаючи лише вертикальний ритм списків. */
+    margin-bottom: 10px;
+}
 .foot_links a {
-    float: left;
-    margin-right: 25px;
+    display: inline-block;
     color: #0A522A;
     text-decoration: underline;
+    padding: 5px 0;
 }
 .foot_links a:hover {
     color: #3ac469;
 }
-.foot_links a:last-child {
-    margin-right: 0;
+@media (max-width: 767px) {
+    /* На вузьких екранах великі зони натискання та один стовпець полегшують навігацію. */
+    .footer {
+        padding-top: 15px;
+    }
+    .foot_links a {
+        display: block;
+        padding: 7px 0;
+    }
+    .copyright {
+        float: none;
+        display: block;
+        padding: 5px 15px 0;
+    }
 }
 .left_auth_name {
     float: left;

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -1521,6 +1521,7 @@ span.item_list_poll:hover {
 }
 .footer {
     /* Автоматична висота дає футеру безпечно зростати разом із кількістю сторінок. */
+    height: auto;
     min-height: 80px;
     background: #dce6e4;
     border-top: 3px solid #c4cfcd;


### PR DESCRIPTION
### Motivation
- Футер має адекватно відображати велику кількість сторінок, переміщуючи їх у стовпці замість одного довгого рядка, зберігаючи наявні стилі й семантику.
- Потрібно покращити юзер-інтерфейс на мобільних пристроях (більші зони натискання, один стовпець) без значного додавання нових CSS-правил.

### Description
- У `frontend/views/layouts/main/footer.php` додано логіку розподілу посилань: обчислюється `footerColumnCount` (до 4), масив посилань розбивається через `array_chunk`, і рендериться семантична навігація через `<nav>` + `<ul>/<li>` з безпечним кодуванням URL і тексту (`Html::encode`).
- У `frontend/web/css/main.css` замінено фіксовану висоту на `min-height`, додано `padding-bottom`, вертикальні відступи для списків і мобільні правила (`@media (max-width: 767px)`) щоб показувати посилання в один стовпець з більшими зонами натискання; при цьому використано наявну Bootstrap-сітку (`col-xs-12 col-sm-*`).
- Збережено принцип «не нашкодь»: мінімальні стилістичні правки, коментарі в коді й повторне використання існуючих класів/залежностей.

### Testing
- `php -l frontend/views/layouts/main/footer.php` пройшов без синтаксичних помилок (успішно).
- `git diff --check` перевірка пройшла без помилок (успішно).
- Алгоритм розподілу посилань перевірено через `php -r '...` для наборів 0, 1, 4, 5, 9, 13, 40 елементів і отримано очікувані параметри колонок/чанків (успішно).
- `php vendor/bin/phpunit --testsuite frontend-unit` запустив PHPUnit, але в цьому тестовому наборі не знайдено тестів (відповідь: "No tests executed").
- `codecept` для frontend не вдалося виконати через відсутній локальний конфіг-файл `frontend/config/codeception-local.php` (помилка середовища при запуску автоматизованих тестів).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a686f8d1620832fa87e7155bdda14b4)