### PR TITLE
Додано адаптивні відступи тексту на головній сторінці

### DIFF
--- a/frontend/web/css/custom.css
+++ b/frontend/web/css/custom.css
@@ -319,6 +319,15 @@ h1.title {
     letter-spacing: .04em;
 }
 
+/* На мобільних і планшетах додаємо тексту головної сторінки невеликі бічні відступи. */
+@media (max-width: 991px) {
+    .homepage_text {
+        box-sizing: border-box;
+        padding-right: 1.5%;
+        padding-left: 1.5%;
+    }
+}
+
 /*
  * Базовий cookie banner у стилі "як на більшості сайтів США":
  * - фіксований блок унизу;

--- a/frontend/web/css/custom.css
+++ b/frontend/web/css/custom.css
@@ -323,8 +323,8 @@ h1.title {
 @media (max-width: 991px) {
     .homepage_text {
         box-sizing: border-box;
-        padding-right: 1.5%;
-        padding-left: 1.5%;
+        padding-right: 2%;
+        padding-left: 2%;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Покращити відображення текстового блоку на головній сторінці на вузьких екранах шляхом додавання бічних відступів для кращої читабельності та уникнення прилипання до країв екрану.

### Description
- Додано медіа-правило в `frontend/web/css/custom.css`, яке для `.homepage_text` при `max-width: 991px` встановлює `box-sizing: border-box; padding-left: 1.5%; padding-right: 1.5%;`, залишаючи десктопне відображення без змін, та додано український коментар біля правила.

### Testing
- Виконано автоматичні перевірки: `git diff --check`, перевірку балансування фігурних дужок у CSS за допомогою PHP-скрипта, та ствердження чистоти робочого дерева через `git status --short`, і всі перевірки пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68ff97f358832f94b164a633ccc2f0)