### PR TITLE
Прибрати дублювання сповіщень в адмінці

### DIFF
--- a/backend/views/cookie-consent-setting/index.php
+++ b/backend/views/cookie-consent-setting/index.php
@@ -15,12 +15,6 @@ $this->title = 'Cookie consent';
 <div class="cookie-consent-setting-index">
     <h1><?= Html::encode($this->title) ?></h1>
 
-    <?php if (Yii::$app->session->hasFlash('success')): ?>
-        <div class="alert alert-success">
-            <?= Html::encode(Yii::$app->session->getFlash('success')) ?>
-        </div>
-    <?php endif; ?>
-
     <div class="box box-primary">
         <div class="box-header with-border">
             <h3 class="box-title">Нове правило</h3>
@@ -84,4 +78,3 @@ $this->title = 'Cookie consent';
         </div>
     </div>
 </div>
-

--- a/backend/views/footer-link/index.php
+++ b/backend/views/footer-link/index.php
@@ -15,12 +15,6 @@ $this->title = 'Футер';
 <div class="footer-link-index">
     <h1><?= Html::encode($this->title) ?></h1>
 
-    <?php if (Yii::$app->session->hasFlash('success')): ?>
-        <div class="alert alert-success">
-            <?= Html::encode(Yii::$app->session->getFlash('success')) ?>
-        </div>
-    <?php endif; ?>
-
     <div class="box box-primary">
         <div class="box-header with-border">
             <h3 class="box-title">Нове посилання футера</h3>

--- a/backend/views/layouts/content.php
+++ b/backend/views/layouts/content.php
@@ -37,6 +37,7 @@ use dmstr\widgets\Alert;
     </section>
 
     <section class="content">
+        <?php // Усі flash-повідомлення адмінки показуємо лише тут, щоб сторінки не дублювали їх. ?>
         <?= Alert::widget() ?>
         <?= $content ?>
     </section>

--- a/backend/views/redirect/index.php
+++ b/backend/views/redirect/index.php
@@ -14,12 +14,6 @@ $this->title = 'Редіректи';
 <div class="redirect-index">
     <h1><?= Html::encode($this->title) ?></h1>
 
-    <?php if (Yii::$app->session->hasFlash('success')): ?>
-        <div class="alert alert-success">
-            <?= Html::encode(Yii::$app->session->getFlash('success')) ?>
-        </div>
-    <?php endif; ?>
-
     <div class="box box-primary">
         <div class="box-header with-border">
             <h3 class="box-title">Новий редірект</h3>


### PR DESCRIPTION
### Motivation

- В адмінці дублювались flash-повідомлення: одне централізоване у шаблоні та повторні локальні блоки на сторінках, через що користувач бачив два однакові зелені сповіщення. 
- Потрібно показувати тільки одне повідомлення (централізовано зверху), щоб уникнути плутанини та дублювання інтерфейсу.

### Description

- Видалено локальні блоки виведення flash-повідомлень зі сторінок `backend/views/footer-link/index.php`, `backend/views/redirect/index.php` та `backend/views/cookie-consent-setting/index.php` щоб вони більше не повторювали централізоване повідомлення. 
- Залишено єдине місце показу flash-повідомлень у шаблоні `backend/views/layouts/content.php` через виклик `Alert::widget()` і додано коментар, що вказує правило централізованого показу повідомлень. 
- Зміни не зачіпають логіку створення flash-повідомлень у контролерах, тільки видаляють локальне відображення у представленнях. 

### Testing

- Прогнано `git diff --check` і проблем синтаксису у змінених файлах не виявлено. 
- Перевірено синтаксис PHP командою `php -l` для `backend/views/layouts/content.php`, `backend/views/footer-link/index.php`, `backend/views/redirect/index.php` і `backend/views/cookie-consent-setting/index.php`, і всі файли пройшли перевірку. 
- Перевірено відсутність локальних викликів flash-повідомлень у представленнях адмінки за допомогою `rg`, і дублювань не знайдено (окрім окремого шаблону стороннього модуля користувачів). 
- Запущено тести `php vendor/bin/phpunit`, результат: 1 тест, 1 твердження, успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ba4b0fc88832f845a9d95b96cb600)