### PR TITLE
Add AJAX-backed user search for Poll form Select2

### DIFF
--- a/backend/modules/poll/controllers/PollController.php
+++ b/backend/modules/poll/controllers/PollController.php
@@ -39,10 +39,14 @@ class PollController extends Controller
     {
         Yii::$app->response->format = Response::FORMAT_JSON;
         // Увесь список завантажується лише після відкриття поля, а не разом зі сторінкою форми.
+        $query = User::find()->select(['id', 'username'])->orderBy('username');
+        if ($term = trim((string)$this->request->get('q', ''))) {
+            $query->andWhere(['like', 'username', $term]);
+        }
         return [
             'results' => array_map(static function (array $user): array {
                 return ['id' => (string)$user['id'], 'text' => $user['username']];
-            }, User::find()->select(['id', 'username'])->orderBy('username')->asArray()->all()),
+            }, $query->asArray()->all()),
         ];
     }
 

--- a/backend/modules/poll/controllers/PollController.php
+++ b/backend/modules/poll/controllers/PollController.php
@@ -4,9 +4,12 @@ namespace backend\modules\poll\controllers;
 
 use common\models\PollFaq;
 use common\models\Poll;
+use common\models\User;
 use common\models\search\PollSearch;
+use Yii;
 use yii\web\Controller;
 use yii\web\NotFoundHttpException;
+use yii\web\Response;
 use yii\filters\VerbFilter;
 
 /**
@@ -30,6 +33,17 @@ class PollController extends Controller
                 ],
             ]
         );
+    }
+
+    public function actionUserSearch(): array
+    {
+        Yii::$app->response->format = Response::FORMAT_JSON;
+        // Увесь список завантажується лише після відкриття поля, а не разом зі сторінкою форми.
+        return [
+            'results' => array_map(static function (array $user): array {
+                return ['id' => (string)$user['id'], 'text' => $user['username']];
+            }, User::find()->select(['id', 'username'])->orderBy('username')->asArray()->all()),
+        ];
     }
 
     /**

--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -1,6 +1,7 @@
 <?php
 
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 
 use kartik\select2\Select2;
@@ -66,11 +67,13 @@ use common\models\PollFaq;
             ]);
             ?>
 
+    <?php $currentUser = $model->user_id ? User::findOne((int)$model->user_id) : null; ?>
     <?= $form->field($model, 'user_id')->widget(Select2::classname(), [
-                'data' => User::dropDownAllItems(),
+                'data' => $currentUser ? [$currentUser->id => $currentUser->username] : [],
                 'language' => Yii::$app->language,
                 'options' => ['placeholder' => Yii::t('app', 'Select user...')],
-                'pluginOptions' => ['allowClear' => true,],
+                // Повний список завантажується через AJAX лише після відкриття поля, щоб форма відкривалася швидко.
+                'pluginOptions' => ['allowClear' => true, 'ajax' => ['url' => Url::to(['user-search']), 'dataType' => 'json']],
             ]);
             ?>
 

--- a/backend/modules/poll/views/poll/_form.php
+++ b/backend/modules/poll/views/poll/_form.php
@@ -73,7 +73,7 @@ use common\models\PollFaq;
                 'language' => Yii::$app->language,
                 'options' => ['placeholder' => Yii::t('app', 'Select user...')],
                 // Повний список завантажується через AJAX лише після відкриття поля, щоб форма відкривалася швидко.
-                'pluginOptions' => ['allowClear' => true, 'ajax' => ['url' => Url::to(['user-search']), 'dataType' => 'json']],
+                'pluginOptions' => ['allowClear' => true, 'ajax' => ['url' => Url::to(['user-search']), 'dataType' => 'json', 'delay' => 300]],
             ]);
             ?>
 


### PR DESCRIPTION
### Motivation
- Avoid loading the full users list when opening the Poll create/edit form to improve form load time and responsiveness.
- Provide a Select2-compatible AJAX endpoint to populate the user selector on demand.

### Description
- Added `actionUserSearch` to `backend/modules/poll/controllers/PollController.php` which returns JSON `results` with `id` and `text` fields for Select2, and imported `User`, `Yii`, and `Response` as needed.
- Updated the poll form view `backend/modules/poll/views/poll/_form.php` to import `Url`, initialize the Select2 `user_id` field with only the current user when present, and configure `pluginOptions.ajax` to call the `user-search` endpoint so the full list is loaded on demand.
- Kept existing behavior of allowing clearing the selection and preserved current display value for the loaded user to ensure backward compatibility.

### Testing
- Ran the backend automated test suite with `phpunit` and verified there were no regressions; all tests passed.
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6da2456624832fb1d245b2ea7094e9)