### PR TITLE
Виправити футер на мобільних пристроях і планшетах

### DIFF
--- a/frontend/views/layouts/main/footer.php
+++ b/frontend/views/layouts/main/footer.php
@@ -11,40 +11,24 @@ use yii\helpers\Html;
 $prefix =  ('https://online-statistics.org' !=  Yii::$app->request->hostinfo) ? '' : 'https://en.online-statistics.org';
 // Отримуємо набір посилань для поточної мови + глобальні посилання для всіх мов.
 $footerLinks = FooterLink::getForLanguage((string) Yii::$app->language);
-// Розподіляємо довгий список максимум на чотири рівномірні стовпці.
-$footerColumnCount = min(4, max(1, (int) ceil(count($footerLinks) / 4)));
-$footerLinkColumns = [];
-$footerLinkOffset = 0;
-$footerLinksPerColumn = intdiv(count($footerLinks), $footerColumnCount);
-$footerColumnsWithExtraLink = count($footerLinks) % $footerColumnCount;
-for ($columnIndex = 0; $columnIndex < $footerColumnCount; $columnIndex++) {
-    // Перші стовпці отримують по одному залишковому посиланню, тому різниця не перевищує одного пункту.
-    $footerColumnSize = $footerLinksPerColumn + ($columnIndex < $footerColumnsWithExtraLink ? 1 : 0);
-    if ($footerColumnSize > 0) {
-        $footerLinkColumns[] = array_slice($footerLinks, $footerLinkOffset, $footerColumnSize);
-        $footerLinkOffset += $footerColumnSize;
-    }
-}
-$footerColumnClass = 'col-xs-12 col-sm-' . (12 / $footerColumnCount);
 ?>
 <!-- Footer
 ================================================== -->
 <footer class="footer">
     <div class="container">
         <nav class="row foot_links" aria-label="Footer navigation">
-            <?php foreach ($footerLinkColumns as $footerLinkColumn): ?>
-                <ul class="<?= $footerColumnClass; ?> list-unstyled">
-                    <?php foreach ($footerLinkColumn as $footerLink): ?>
-                        <?php
-                        // Не нашкодь: виводимо дані безпечно, а URL приводимо до валідного виду.
-                        $url = preg_match('/^https?:\/\//i', (string) $footerLink->url)
-                            ? $footerLink->url
-                            : Url::to($footerLink->url);
-                        ?>
-                        <li><a href="<?= Html::encode($url); ?>"><?= Html::encode($footerLink->anchor); ?></a></li>
-                    <?php endforeach; ?>
-                </ul>
-            <?php endforeach; ?>
+            <!-- Єдиний список дає CSS змогу рівномірно розкласти посилання на кожній ширині екрана. -->
+            <ul class="col-xs-12 list-unstyled">
+                <?php foreach ($footerLinks as $footerLink): ?>
+                    <?php
+                    // Не нашкодь: виводимо дані безпечно, а URL приводимо до валідного виду.
+                    $url = preg_match('/^https?:\/\//i', (string) $footerLink->url)
+                        ? $footerLink->url
+                        : Url::to($footerLink->url);
+                    ?>
+                    <li><a href="<?= Html::encode($url); ?>"><?= Html::encode($footerLink->anchor); ?></a></li>
+                <?php endforeach; ?>
+            </ul>
         </nav>
         <div class="row">
             <span class="copyright">All Rights Reserved | <?= date('Y'); ?></span>

--- a/frontend/web/css/main.css
+++ b/frontend/web/css/main.css
@@ -1534,8 +1534,14 @@ span.item_list_poll:hover {
     padding-right: 3%;
 }
 .foot_links ul {
-    /* Використовуємо наявну Bootstrap-сітку, додаючи лише вертикальний ритм списків. */
+    /* На широких екранах компактно заповнюємо футер чотирма рівномірними стовпцями. */
+    column-count: 4;
+    column-gap: 30px;
     margin-bottom: 10px;
+}
+.foot_links li {
+    /* Не розриваємо окреме посилання між стовпцями. */
+    break-inside: avoid;
 }
 .foot_links a {
     display: inline-block;
@@ -1546,10 +1552,14 @@ span.item_list_poll:hover {
 .foot_links a:hover {
     color: #3ac469;
 }
-@media (max-width: 767px) {
-    /* На вузьких екранах великі зони натискання та один стовпець полегшують навігацію. */
+@media (max-width: 991px) {
+    /* На телефонах і планшетах два стовпці прибирають зайву висоту, не зменшуючи зони натискання. */
     .footer {
         padding-top: 15px;
+    }
+    .foot_links ul {
+        column-count: 2;
+        column-gap: 20px;
     }
     .foot_links a {
         display: block;


### PR DESCRIPTION
### Motivation
- Футер виглядав коректно на десктопі, але некоректно на мобільних і планшетах, тому потрібно покращити адаптивне компонування з мінімальними змінами в коді.

### Description
- Замінено серверне розбиття посилань на кілька списків одним семантичним списком у `frontend/views/layouts/main/footer.php`, збережено безпечну нормалізацію URL та екранування виводу.
- Додано CSS-більш кероване компонування у `frontend/web/css/main.css`: `column-count: 4` для десктопів, `column-count: 2` для екранів до `991px`, `column-gap` для відступів та `break-inside: avoid` для запобігання розриву окремих посилань між колонками; також виправлено висоту та відступи футера.
- Додав підписи/коментарі українською у шаблоні та стилях, зміни обмежені лише файлом шаблона та CSS і мінімізують серверний код.

### Testing
- `php -l frontend/views/layouts/main/footer.php` — синтаксично без помилок (OK).
- `php vendor/bin/phpunit --configuration phpunit.xml` — пройдено автоматичні тести (1 тест, 1 твердження, OK).
- Статичні перевірки (`git diff --check`) не виявили проблем під час тестування.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e5ba175d0832fb3b4417ebce394ca)